### PR TITLE
USB printing with short sleep

### DIFF
--- a/lib/Printer/ESCPOS/Connections/USB.pm
+++ b/lib/Printer/ESCPOS/Connections/USB.pm
@@ -68,7 +68,6 @@ has _connection => (
     init_arg   => undef,
 );
 
-
 sub _build__connection {
     my ($self) = @_;
 
@@ -125,7 +124,6 @@ sub print {
         usleep(5000);    # USB Port is sometimes annoying, it doesn't always tell you when it is ready to get the next chunk
     }
 }
-
 
 no Moo;
 __PACKAGE__->meta->make_immutable;

--- a/lib/Printer/ESCPOS/Connections/USB.pm
+++ b/lib/Printer/ESCPOS/Connections/USB.pm
@@ -121,7 +121,7 @@ sub print {
     @chunks = unpack "a$n" x ( ( length($buffer) / $n ) - 1 ) . "a*", $buffer;
     for my $chunk (@chunks) {
         $self->_connection->bulk_write($self->endPoint, $chunk, $self->timeout);
-        usleep(5000);    # USB Port is sometimes annoying, it doesn't always tell you when it is ready to get the next chunk
+        usleep(10000);    # USB Port is sometimes annoying, it doesn't always tell you when it is ready to get the next chunk
     }
 }
 


### PR DESCRIPTION
I had problem with a USB printer (Citizen CT-S4000) printing garbage when there was too much in the buffer. So I added a little sleep time between sending chunks (similar to the way it is done in the Serial driver).

Maybe we should add an option for this, so the user can decide if it should be used. Probably other printers do not have such a problem or need another chunk size / sleep time to work well.