### PR TITLE
Subject: Fix Issue #6: Refactor core logic to prevent crashes...

### DIFF
--- a/lib/Printer/ESCPOS.pm
+++ b/lib/Printer/ESCPOS.pm
@@ -5,8 +5,15 @@ package Printer::ESCPOS;
 
 # PODNAME: Printer::ESCPOS
 # ABSTRACT: Interface for all thermal, dot-matrix and other receipt printers that support ESC-POS specification.
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 # Dependencies
 use 5.010;
@@ -16,7 +23,306 @@ use Carp;
 use Type::Tiny;
 use aliased 'Printer::ESCPOS::Roles::Profile' => 'ESCPOSProfile';
 
-=attr driverType
+
+has driverType => (
+    is       => 'ro',
+    required => 1,
+);
+
+
+has profile => (
+    is      => 'ro',
+    default => 'Generic',
+);
+
+
+has deviceFilePath => ( is => 'ro', );
+
+
+has portName => ( is => 'ro', );
+
+
+has deviceIP => ( is => 'ro', );
+
+
+has devicePort => (
+    is      => 'ro',
+    default => '9100',
+);
+
+
+has baudrate => (
+    is      => 'ro',
+    default => 38400,
+);
+
+
+has serialOverUSB => (
+    is      => 'ro',
+    default => '1',
+);
+
+
+has vendorId => ( is => 'ro', );
+
+
+has productId => ( is => 'ro', );
+
+
+has endPoint => (
+    is      => 'ro',
+    default => 0x01,
+);
+
+
+has timeout => (
+    is       => 'ro',
+    required => 1,
+    default  => 1000,
+);
+
+has _driver => (
+    is       => 'lazy',
+    init_arg => undef,
+);
+
+sub _build__driver {
+    my ($self) = @_;
+
+    if ( $self->driverType eq 'File' ) {
+        Class::Load::load_class('Printer::ESCPOS::Connections::File');
+        return Printer::ESCPOS::Connections::File->new(
+            deviceFilePath => $self->deviceFilePath, );
+    }
+    elsif ( $self->driverType eq 'Network' ) {
+        Class::Load::load_class('Printer::ESCPOS::Connections::Network');
+        return Printer::ESCPOS::Connections::Network->new(
+            deviceIP   => $self->deviceIP,
+            devicePort => $self->devicePort,
+        );
+    }
+    elsif ( $self->driverType eq 'Serial' ) {
+        Class::Load::load_class('Printer::ESCPOS::Connections::Serial');
+        return Printer::ESCPOS::Connections::Serial->new(
+            deviceFilePath => $self->deviceFilePath,
+            baudrate       => $self->baudrate,
+            serialOverUSB  => $self->serialOverUSB,
+        );
+    }
+    elsif ( $self->driverType eq 'USB' ) {
+        Class::Load::load_class('Printer::ESCPOS::Connections::USB');
+        return Printer::ESCPOS::Connections::USB->new(
+            productId => $self->productId,
+            vendorId  => $self->vendorId,
+            endPoint  => $self->endPoint,
+            timeout   => $self->timeout,
+        );
+    }
+}
+
+
+has printer => ( is => 'lazy', );
+
+sub _build_printer {
+    my ($self) = @_;
+
+    my $base  = __PACKAGE__ . "::Profiles::";
+    my $class = $base . $self->profile;
+
+    Class::Load::load_class($class);
+    unless ( $class->does(ESCPOSProfile) ) {
+        confess
+"Class ${class} in ${base} does not implement the Printer::ESCPOS::Roles::Profile Interface";
+    }
+    my $object = $class->new( driver => $self->_driver, );
+
+    $object->init();
+
+    return $object;
+}
+
+no Moo;
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Printer::ESCPOS - Interface for all thermal, dot-matrix and other receipt printers that support ESC-POS specification.
+
+
+
+=begin html
+
+<p>
+<img src="https://img.shields.io/badge/perl-5.10+-brightgreen.svg" alt="Requires Perl 5.10+" />
+<a href="https://travis-ci.org/shantanubhadoria/perl-Printer-ESCPOS"><img src="https://api.travis-ci.org/shantanubhadoria/perl-Printer-ESCPOS.svg?branch=build/master" alt="Travis status" /></a>
+<a href="http://matrix.cpantesters.org/?dist=Printer-ESCPOS%201.006"><img src="http://badgedepot.code301.com/badge/cpantesters/Printer-ESCPOS/1.006" alt="CPAN Testers result" /></a>
+<a href="http://cpants.cpanauthors.org/release/_/Printer-ESCPOS-1.006"><img src="http://badgedepot.code301.com/badge/kwalitee/_/Printer-ESCPOS/1.006" alt="Distribution kwalitee" /></a>
+<a href="https://gratipay.com/shantanubhadoria"><img src="https://img.shields.io/gratipay/shantanubhadoria.svg" alt="Gratipay" /></a>
+</p>
+
+=end html
+
+=head1 VERSION
+
+version 1.006
+
+=head1 SYNOPSIS
+
+If you are just starting up with POS RECEIPT Printers, you must first refer to L<Printer::ESCPOS::Manual> to get started.
+
+Printer::ESCPOS provides four different types of printer connections to talk to a ESCPOS printer.
+As of v0.012 I<driverType> B<Serial>, B<Network>, B<File> and B<USB> are all implemented in this module. B<USB> I<driverType>
+is not supported prior to v0.012.
+
+=head2 USB Printer
+
+B<USB> I<driverType> allows you to talk to your Printer using the I<vendorId> and I<productId> values for your printer.
+These can be retrieved using lsusb command
+
+     shantanu@shantanu-G41M-ES2L:~/github$ lsusb
+     . . .
+     Bus 003 Device 002: ID 1504:0006
+     . . .
+
+The output gives us the I<vendorId> 0x1504 and I<productId> 0x0006
+
+For USB Printers L<Printer::ESCPOS> uses a default I<endPoint> of 0x01 and a default I<timeout> of
+1000, however these can be specified manually in case your printer requires a different value.
+
+     use Printer::ESCPOS;
+ 
+     my $vendorId  = 0x1504;
+     my $productId = 0x0006;
+     my $device = Printer::ESCPOS->new(
+         driverType     => 'USB',
+         vendorId       => $vendorId,
+         productId      => $productId,
+     );
+ 
+     use GD;
+     my $img = newFromGif GD::Image('header.gif') || die "Error $!";
+     $device->printer->image($img); # Takes a GD image object
+ 
+     $device->printer->qr("Don't Panic!"); # Print a QR Code
+ 
+     $device->printer->printAreaWidth(5000);
+     $device->printer->text("Print Area Width Modified\n");
+     $device->printer->printAreaWidth(); # Reset to default
+     $device->printer->text("print area width reset\n");
+     $device->printer->tab();
+     $device->printer->underline(1);
+     $device->printer->text("underline on\n");
+     $device->printer->invert(1);
+     $device->printer->text("Inverted Text\n");
+     $device->printer->justify('right');
+     $device->printer->text("Right Justified\n");
+     $device->printer->upsideDown(1);
+     $device->printer->text("Upside Down\n");
+     $device->printer->cutPaper();
+ 
+     $device->printer->print(); # Dispatch the above commands from module buffer to the Printer.
+
+=head2 Network Printer
+
+For Network Printers $port is 9100 in most cases but might differ depending on how
+you have configured your printer
+
+     use Printer::ESCPOS;
+ 
+     my $printer_id = '192.168.0.10';
+     my $port       = '9100';
+     my $device = Printer::ESCPOS->new(
+         driverType => 'Network',
+         deviceIp   => $printer_ip,
+         devicePort => $port,
+     );
+ 
+     # These commands won't actually send anything to the printer but will store all the
+     # merged data including control codes to module buffer.
+     $device->printer->printAreaWidth(7000);
+     $device->printer->text("Print Area Width Modified\n");
+     $device->printer->printAreaWidth(); # Reset to default
+     $device->printer->text("print area width reset\n");
+     $device->printer->tab();
+     $device->printer->underline(1);
+     $device->printer->text("underline on\n");
+     $device->printer->invert(1);
+     $device->printer->text("Inverted Text\n");
+     $device->printer->justify('right');
+     $device->printer->text("Right Justified\n");
+     $device->printer->upsideDown(1);
+     $device->printer->text("Upside Down\n");
+     $device->printer->cutPaper();
+ 
+     $device->printer->print(); # Dispatch the above commands from module buffer to the Printer.
+                                # This command takes care of read text buffers for the printer.
+
+=head2 Serial Printer
+
+Use the B<Serial> I<driverType> for local printer connected on serial port(or a printer connected via
+a physical USB port in USB to Serial mode), check syslog(Usually under E<sol>varE<sol>logE<sol>syslog)
+for what device file was created for your printer when you connect it to your system(For
+plug and play printers). You may also use a Windows port name like 'COM1', 'COM2' etc. as
+deviceFilePath param when running this under windows. The Device::SerialPort claims to support this
+syntax. (Drop me a email if you are able to make it work in windows as I have not tested it out yet)
+
+     use Printer::ESCPOS;
+     use Data::Dumper; # Just to get dumps of status functions supported for Serial driverType.
+ 
+     my $path = '/dev/ttyACM0';
+     $device = Printer::ESCPOS->new(
+         driverType     => 'Serial',
+         deviceFilePath => $path,
+     );
+ 
+     say Dumper $device->printer->printerStatus();
+     say Dumper $device->printer->offlineStatus();
+     say Dumper $device->printer->errorStatus();
+     say Dumper $device->printer->paperSensorStatus();
+ 
+     $device->printer->bold(1);
+     $device->printer->text("Bold Text\n");
+     $device->printer->bold(0);
+     $device->printer->text("Bold Text Off\n");
+ 
+     $device->printer->print();
+
+=head2 File(Direct to Device File) Printer
+
+A B<File> I<driverType> is similar to the B<Serial> I<driverType> in all functionality except that it
+doesn't support the status functions for the printer. i.e. you will not be able to use
+printerStatus, offlineStatus, errorStatus or paperSensorStatus functions
+
+     use Printer::ESCPOS;
+ 
+     my $path = '/dev/usb/lp0';
+     $device = Printer::ESCPOS->new(
+         driverType     => 'File',
+         deviceFilePath => $path,
+     );
+ 
+     $device->printer->bold(1);
+     $device->printer->text("Bold Text\n");
+     $device->printer->bold(0);
+     $device->printer->text("Bold Text Off\n");
+ 
+     $device->printer->print();
+
+=head1 DESCRIPTION
+
+You can use this module for all your ESC-POS Printing needs. If some of your printer's functions are not included, you
+may extend this module by adding specialized funtions for your printer in it's own subclass. Refer to
+L<Printer::ESCPOS::Roles::Profile> and L<Printer::ESCPOS::Profiles::Generic>
+
+=head1 ATTRIBUTES
+
+=head2 driverType
 
 "Required attribute". The driver type to use for your printer. This can be B<File>, B<Network>, B<USB> or B<Serial>.
 If you choose B<File> or B<Serial> driver, you must provide the I<deviceFilePath>,
@@ -59,14 +365,7 @@ File driver type:
         deviceFilePath => $path,
     );
 
-=cut
-
-has driverType => (
-    is       => 'ro',
-    required => 1,
-);
-
-=attr profile
+=head2 profile
 
 There are minor differences in ESC POS printers across different brands and models in terms of specifications and extra
 features. For using special features of a particular brand you may create a sub class in the name space
@@ -94,106 +393,48 @@ override the generic class pass the I<profile> Param during object creation.
 
 The above $device object will use the Printer::ESCPOS::Profile::USERCUSTOM profile.
 
-=cut
-
-has profile => (
-    is      => 'ro',
-    default => 'Generic',
-);
-
-=attr deviceFilePath
+=head2 deviceFilePath
 
 File path for UNIX device file. e.g. "/dev/ttyACM0", or port name for Win32 (untested) like 'COM1', COM2' etc. This is a
 mandatory parameter if you are using B<File> or B<Serial> I<driverType>. I haven't had a chance to test this on windows
 so if you are able to successfully use this with a serial port on windows, drop me a email to let me know that I got it
 right :)
 
-=cut
-
-has deviceFilePath => (
-    is  => 'ro',
-);
-
-=attr portName
+=head2 portName
 
 Win32 serial port name
 
-=cut
-
-has portName => (
-    is  => 'ro',
-);
-
-=attr deviceIP
+=head2 deviceIP
 
 Contains the IP address of the device when its a network printer. The module creates L<IO:Socket::INET> object to
 connect to the printer. This can be passed in the constructor.
 
-=cut
-
-has deviceIP => (
-  is  => 'ro',
-);
-
-=attr devicePort
+=head2 devicePort
 
 Contains the network port of the device when its a network printer. The module creates L<IO:Socket::INET> object to
 connect to the printer. This can be passed in the constructor.
 
-=cut
-
-has devicePort => (
-  is      => 'ro',
-  default => '9100',
-);
-
-=attr baudrate
+=head2 baudrate
 
 When used as a local serial device you can set the I<baudrate> of the printer too. Default (38400) will usually work,
 but not always.
 
-=cut
-
-has baudrate => (
-  is      => 'ro',
-  default => 38400,
-);
-
-=attr serialOverUSB
+=head2 serialOverUSB
 
 Set this value to 1 if you are connecting your printer using the USB Cable but it shows up as a serial device and you
 are using the B<Serial> driver.
 
-=cut
-
-has serialOverUSB => (
-  is      => 'ro',
-  default => '1',
-);
-
-=attr vendorId
+=head2 vendorId
 
 This is a required param for B<USB> I<driverType>. It contains the USB printer's Vendor ID when using B<USB>
 I<driverType>. Use lsusb command to get this value for your printer.
 
-=cut
-
-has vendorId => (
-    is         => 'ro',
-);
-
-=attr productId
+=head2 productId
 
 This is a required param for B<USB> I<driverType>. It contains the USB printer's product Id when using B<USB>
 I<driverType>. Use lsusb command to get this value for your printer.
 
-=cut
-
-has productId => (
-    is         => 'ro',
-);
-
-=attr endPoint
+=head2 endPoint
 
 This is a optional param for B<USB> I<driverType>. It contains the USB endPoint for L<Device::USB> to write to if the
 value is not 0x01 for your printer. Get it using the following command:
@@ -203,292 +444,166 @@ value is not 0x01 for your printer. Get it using the following command:
 
 Replace 1504:0006 with your own printer's vendor id and product id in the above command.
 
-=cut
-
-has endPoint => (
-    is       => 'ro',
-    default  => 0x01,
-);
-
-=attr timeout
+=head2 timeout
 
 Timeout for bulk write functions for the USB printer. Optional param.
 
-=cut
-
-has timeout => (
-    is       => 'ro',
-    required => 1,
-    default  => 1000,
-);
-
-has _driver => (
-    is         => 'lazy',
-    init_arg   => undef,
-);
-
-sub _build__driver {
-    my ( $self ) = @_;
-
-    if( $self->driverType eq 'File' ) {
-        Class::Load::load_class( 'Printer::ESCPOS::Connections::File' );
-        return Printer::ESCPOS::Connections::File->new(
-            deviceFilePath => $self->deviceFilePath,
-        );
-    } elsif( $self->driverType eq 'Network' ) {
-        Class::Load::load_class( 'Printer::ESCPOS::Connections::Network' );
-        return Printer::ESCPOS::Connections::Network->new(
-            deviceIP   => $self->deviceIP,
-            devicePort => $self->devicePort,
-        );
-    } elsif( $self->driverType eq 'Serial' ) {
-        Class::Load::load_class( 'Printer::ESCPOS::Connections::Serial' );
-        return Printer::ESCPOS::Connections::Serial->new(
-            deviceFilePath => $self->deviceFilePath,
-            baudrate       => $self->baudrate,
-            serialOverUSB  => $self->serialOverUSB,
-        );
-    } elsif( $self->driverType eq 'USB' ) {
-        Class::Load::load_class( 'Printer::ESCPOS::Connections::USB' );
-        return Printer::ESCPOS::Connections::USB->new(
-            productId => $self->productId,
-            vendorId  => $self->vendorId,
-            endPoint  => $self->endPoint,
-            timeout   => $self->timeout,
-        );
-    }
-}
-
-=attr printer
+=head2 printer
 
 Use this attribute to send commands to the printer
 
     $device->printer->setFont('a');
     $device->printer->text("blah blah blah\n");
 
-=cut
+=head1 USAGE
 
-has printer => (
-    is         => 'lazy',
-);
+Refer to the following manual to get started with L<Printer::ESCPOS>
 
-sub _build_printer {
-    my ( $self ) = @_;
+=over
 
-    my $base  = __PACKAGE__ . "::Profiles::";
-    my $class = $base . $self->profile;
+=item *
 
-    Class::Load::load_class($class);
-    unless ($class->does(ESCPOSProfile)){
-        confess "Class ${class} in ${base} does not implement the Printer::ESCPOS::Roles::Profile Interface";
-    }
-    my $object = $class->new(
-        driver => $self->_driver,
-    );
+L<Printer::ESCPOS::Manual>
 
-    $object->init();
+=back
 
-    return $object;
-}
+=head2 Quick usage summary in steps:
 
-no Moo;
-__PACKAGE__->meta->make_immutable;
+=over
 
-1;
+=item 1.
 
-__END__
+Create a device object $device by providing parameters for one of the supported printer types. Call
+$device-E<gt>printer-E<gt>init to initialize the printer.
 
-=begin wikidoc
+=item 2.
 
-= SYNOPSIS
+call text() and other Text formatting functions on $device-E<gt>printer for the data to be sent to the printer. Make sure
+to end it all with a linefeed $device-E<gt>printer-E<gt>lf().
 
-If you are just starting up with POS RECEIPT Printers, you must first refer to [Printer::ESCPOS::Manual] to get started.
+=item 3.
 
-Printer::ESCPOS provides four different types of printer connections to talk to a ESCPOS printer.
-As of v0.012 ~driverType~ *Serial*, *Network*, *File* and *USB* are all implemented in this module. *USB* ~driverType~
-is not supported prior to v0.012.
+Then call the print() method to dispatch the sequences from the module buffer to the printer
 
-== USB Printer
+=back
 
-*USB* ~driverType~ allows you to talk to your Printer using the ~vendorId~ and ~productId~ values for your printer.
-These can be retrieved using lsusb command
-
-    shantanu@shantanu-G41M-ES2L:~/github$ lsusb
-    . . .
-    Bus 003 Device 002: ID 1504:0006
-    . . .
-
-The output gives us the ~vendorId~ 0x1504 and ~productId~ 0x0006
-
-For USB Printers [Printer::ESCPOS] uses a default ~endPoint~ of 0x01 and a default ~timeout~ of
-1000, however these can be specified manually in case your printer requires a different value.
-
-    use Printer::ESCPOS;
-
-    my $vendorId  = 0x1504;
-    my $productId = 0x0006;
-    my $device = Printer::ESCPOS->new(
-        driverType     => 'USB',
-        vendorId       => $vendorId,
-        productId      => $productId,
-    );
-
-    use GD;
-    my $img = newFromGif GD::Image('header.gif') || die "Error $!";
-    $device->printer->image($img); # Takes a GD image object
-
-    $device->printer->qr("Don't Panic!"); # Print a QR Code
-
-    $device->printer->printAreaWidth(5000);
-    $device->printer->text("Print Area Width Modified\n");
-    $device->printer->printAreaWidth(); # Reset to default
-    $device->printer->text("print area width reset\n");
-    $device->printer->tab();
-    $device->printer->underline(1);
-    $device->printer->text("underline on\n");
-    $device->printer->invert(1);
-    $device->printer->text("Inverted Text\n");
-    $device->printer->justification('right');
-    $device->printer->text("Right Justified\n");
-    $device->printer->upsideDown(1);
-    $device->printer->text("Upside Down\n");
-    $device->printer->cutPaper();
-
-    $device->printer->print(); # Dispatch the above commands from module buffer to the Printer.
-
-== Network Printer
-
-For Network Printers $port is 9100 in most cases but might differ depending on how
-you have configured your printer
-
-    use Printer::ESCPOS;
-
-    my $printer_id = '192.168.0.10';
-    my $port       = '9100';
-    my $device = Printer::ESCPOS->new(
-        driverType => 'Network',
-        deviceIp   => $printer_ip,
-        devicePort => $port,
-    );
-
-    # These commands won't actually send anything to the printer but will store all the
-    # merged data including control codes to module buffer.
-    $device->printer->printAreaWidth(7000);
-    $device->printer->text("Print Area Width Modified\n");
-    $device->printer->printAreaWidth(); # Reset to default
-    $device->printer->text("print area width reset\n");
-    $device->printer->tab();
-    $device->printer->underline(1);
-    $device->printer->text("underline on\n");
-    $device->printer->invert(1);
-    $device->printer->text("Inverted Text\n");
-    $device->printer->justification('right');
-    $device->printer->text("Right Justified\n");
-    $device->printer->upsideDown(1);
-    $device->printer->text("Upside Down\n");
-    $device->printer->cutPaper();
-
-    $device->printer->print(); # Dispatch the above commands from module buffer to the Printer.
-                               # This command takes care of read text buffers for the printer.
-
-== Serial Printer
-
-Use the *Serial* ~driverType~ for local printer connected on serial port(or a printer connected via
-a physical USB port in USB to Serial mode), check syslog(Usually under /var/log/syslog)
-for what device file was created for your printer when you connect it to your system(For
-plug and play printers). You may also use a Windows port name like 'COM1', 'COM2' etc. as
-deviceFilePath param when running this under windows. The Device::SerialPort claims to support this
-syntax. (Drop me a email if you are able to make it work in windows as I have not tested it out yet)
-
-    use Printer::ESCPOS;
-    use Data::Dumper; # Just to get dumps of status functions supported for Serial driverType.
-
-    my $path = '/dev/ttyACM0';
-    $device = Printer::ESCPOS->new(
-        driverType     => 'Serial',
-        deviceFilePath => $path,
-    );
-
-    say Dumper $device->printer->printerStatus();
-    say Dumper $device->printer->offlineStatus();
-    say Dumper $device->printer->errorStatus();
-    say Dumper $device->printer->paperSensorStatus();
-
-    $device->printer->bold(1);
-    $device->printer->text("Bold Text\n");
-    $device->printer->bold(0);
-    $device->printer->text("Bold Text Off\n");
-
-    $device->printer->print();
-
-
-== File(Direct to Device File) Printer
-
-A *File* ~driverType~ is similar to the *Serial* ~driverType~ in all functionality except that it
-doesn't support the status functions for the printer. i.e. you will not be able to use
-printerStatus, offlineStatus, errorStatus or paperSensorStatus functions
-
-    use Printer::ESCPOS;
-
-    my $path = '/dev/usb/lp0';
-    $device = Printer::ESCPOS->new(
-        driverType     => 'File',
-        deviceFilePath => $path,
-    );
-
-    $device->printer->bold(1);
-    $device->printer->text("Bold Text\n");
-    $device->printer->bold(0);
-    $device->printer->text("Bold Text Off\n");
-
-    $device->printer->print();
-
-= DESCRIPTION
-
-You can use this module for all your ESC-POS Printing needs. If some of your printer's functions are not included, you
-may extend this module by adding specialized funtions for your printer in it's own subclass. Refer to
-[Printer::ESCPOS::Roles::Profile] and [Printer::ESCPOS::Profiles::Generic]
-
-= USAGE
-
-Refer to the following manual to get started with [Printer::ESCPOS]
-
-* [Printer::ESCPOS::Manual]
-
-== Quick usage summary in steps:
-
-0 Create a device object $device by providing parameters for one of the supported printer types. Call
-$device->printer->init to initialize the printer.
-0 call text() and other Text formatting functions on $device->printer for the data to be sent to the printer. Make sure
-to end it all with a linefeed $device->printer->lf().
-0 Then call the print() method to dispatch the sequences from the module buffer to the printer
-    $device->printer->print()
+     $device->printer->print()
 
 Note: While you may call print() after every single command code, this is not advisable as some printers tend to choke
 up if you send them too many print commands in quick succession. To avoid this, aggregate the data to be sent to the
 printer with text() and other text formatting functions and then send it all in one go using print() at the very end.
 
-= NOTES
+=head1 NOTES
 
-* In Serial mode if the printer prints out garbled characters instead of proper text, try specifying the baudrate
+=over
+
+=item *
+
+In Serial mode if the printer prints out garbled characters instead of proper text, try specifying the baudrate
 parameter when you create the printer object. The default baudrate is set at 38400
-    $device = Printer::ESCPOS->new(
-        driverType     => 'Serial',
-        deviceFilePath => $path,
-        baudrate       => 9600,
-    );
-* For ESC-P codes refer the guide from Epson [http://support.epson.ru/upload/library_file/14/esc-p.pdf]
 
-= SEE ALSO
+=back
 
-* [Printer::ESCPOS::Manual]
-* [Printer::ESCPOS::Profiles::Generic]
-* [Printer::ESCPOS::Profiles::SinocanPSeries]
-* [Printer::ESCPOS::Roles::Profile]
-* [Printer::ESCPOS::Roles::Connection]
-* [Printer::ESCPOS::Connections::USB]
-* [Printer::ESCPOS::Connections::Serial]
-* [Printer::ESCPOS::Connections::Network]
-* [Printer::ESCPOS::Connections::File]
+     $device = Printer::ESCPOS->new(
+         driverType     => 'Serial',
+         deviceFilePath => $path,
+         baudrate       => 9600,
+     );
 
-=end wikidoc
+=over
+
+=item *
+
+For ESC-P codes refer the guide from Epson L<http://support.epson.ru/upload/library_file/14/esc-p.pdf>
+
+=back
+
+=head1 SEE ALSO
+
+=over
+
+=item *
+
+L<Printer::ESCPOS::Manual>
+
+=item *
+
+L<Printer::ESCPOS::Profiles::Generic>
+
+=item *
+
+L<Printer::ESCPOS::Profiles::SinocanPSeries>
+
+=item *
+
+L<Printer::ESCPOS::Roles::Profile>
+
+=item *
+
+L<Printer::ESCPOS::Roles::Connection>
+
+=item *
+
+L<Printer::ESCPOS::Connections::USB>
+
+=item *
+
+L<Printer::ESCPOS::Connections::Serial>
+
+=item *
+
+L<Printer::ESCPOS::Connections::Network>
+
+=item *
+
+L<Printer::ESCPOS::Connections::File>
+
+=back
+
+=for :stopwords cpan testmatrix url annocpan anno bugtracker rt cpants kwalitee diff irc mailto metadata placeholders metacpan
+
+=head1 SUPPORT
+
+=head2 Bugs / Feature Requests
+
+Please report any bugs or feature requests through github at 
+L<https://github.com/shantanubhadoria/perl-printer-escpos/issues>.
+You will be notified automatically of any progress on your issue.
+
+=head2 Source Code
+
+This is open source software.  The code repository is available for
+public review and contribution under the terms of the license.
+
+L<https://github.com/shantanubhadoria/perl-printer-escpos>
+
+  git clone git://github.com/shantanubhadoria/perl-printer-escpos.git
+
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 CONTRIBUTORS
+
+=for stopwords Dominic Sonntag Shantanu Bhadoria
+
+=over 4
+
+=item *
+
+Dominic Sonntag <dominic@s5g.de>
+
+=item *
+
+Shantanu Bhadoria <shantanu att cpan dott org>
+
+=back
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Printer/ESCPOS/Connections/File.pm
+++ b/lib/Printer/ESCPOS/Connections/File.pm
@@ -47,15 +47,6 @@ sub _build__connection {
     return $printer;
 }
 
-#sub _build__connection {
-#    my ($self) = @_;
-#    my $printer;
-#
-#    $printer = new IO::File ">>" . $self->deviceFilePath;
-#
-#    return $printer;
-#}
-
 sub write {
     my ($self, $chunk) = @_;
 

--- a/lib/Printer/ESCPOS/Connections/File.pm
+++ b/lib/Printer/ESCPOS/Connections/File.pm
@@ -5,8 +5,15 @@ package Printer::ESCPOS::Connections::File;
 
 # PODNAME: Printer::ESCPOS::Connections::File
 # ABSTRACT: Bare Device File Connection Interface for L<Printer::ESCPOS>
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 # Dependencies
 
@@ -16,31 +23,80 @@ with 'Printer::ESCPOS::Roles::Connection';
 
 use IO::File;
 
-=attr deviceFilePath
 
-This variable contains the path for the printer device file on UNIX-like systems.
-
-=cut
-
-has deviceFilePath => (
-  is => 'ro',
-);
+has deviceFilePath => ( is => 'ro', );
 
 has _connection => (
-    is         => 'lazy',
-    init_arg   => undef,
+    is       => 'lazy',
+    init_arg => undef,
 );
 
 sub _build__connection {
     my ($self) = @_;
-    my $printer;
 
-    $printer = new IO::File ">>" . $self->deviceFilePath ;
+    # Ensure the path exists
+    die "deviceFilePath is required for File driver" unless $self->deviceFilePath;
+
+    # Open for appending in binary mode
+    my $printer = IO::File->new( $self->deviceFilePath, ">>" )
+        or die "Could not open " . $self->deviceFilePath . ": $!";
+
+    # Crucial for ESC/POS: Don't let Perl mess with the bytes
+    binmode($printer);
 
     return $printer;
+}
+
+#sub _build__connection {
+#    my ($self) = @_;
+#    my $printer;
+#
+#    $printer = new IO::File ">>" . $self->deviceFilePath;
+#
+#    return $printer;
+#}
+
+sub write {
+    my ($self, $chunk) = @_;
+
+    $self->_connection->print($chunk);
+
+    $self->_connection->autoflush(1);
+    return;
 }
 
 no Moo;
 __PACKAGE__->meta->make_immutable;
 
 1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Printer::ESCPOS::Connections::File - Bare Device File Connection Interface for L<Printer::ESCPOS>
+
+=head1 VERSION
+
+version 1.006
+
+=head1 ATTRIBUTES
+
+=head2 deviceFilePath
+
+This variable contains the path for the printer device file on UNIX-like systems.
+
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Printer/ESCPOS/Connections/Network.pm
+++ b/lib/Printer/ESCPOS/Connections/Network.pm
@@ -5,8 +5,15 @@ package Printer::ESCPOS::Connections::Network;
 
 # PODNAME: Printer::ESCPOS::Connections::Network
 # ABSTRACT: Network Connection Interface for L<Printer::ESCPOS>
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 # Dependencies
 
@@ -16,32 +23,18 @@ with 'Printer::ESCPOS::Roles::Connection';
 
 use IO::Socket;
 
-=attr deviceIP
 
-Contains the IP address of the device when its a network printer. The module creates IO:Socket::INET object to connect
-to the printer. This can be passed in the constructor.
+has deviceIP => ( is => 'ro', );
 
-=cut
-
-has deviceIP => (
-  is  => 'ro',
-);
-
-=attr devicePort
-
-Contains the network port of the device when its a network printer. The module creates IO:Socket::INET object to connect
-to the printer. This can be passed in the constructor.
-
-=cut
 
 has devicePort => (
-  is      => 'ro',
-  default => '9100',
+    is      => 'ro',
+    default => '9100',
 );
 
 has _connection => (
-    is         => 'lazy',
-    init_arg   => undef,
+    is       => 'lazy',
+    init_arg => undef,
 );
 
 sub _build__connection {
@@ -49,29 +42,24 @@ sub _build__connection {
     my $printer;
 
     $printer = IO::Socket::INET->new(
-        Proto     => "tcp",
-        PeerAddr  => $self->deviceIP,
-        PeerPort  => $self->devicePort,
-        Timeout   => 1,
+        Proto    => "tcp",
+        PeerAddr => $self->deviceIP,
+        PeerPort => $self->devicePort,
+        Timeout  => 1,
     ) or die " Can't connect to printer";
 
     return $printer;
 }
 
-=method read
-
-Read Data from the printer
-
-=cut
 
 sub read {
-    my ($self, $question, $bytes) = @_;
+    my ( $self, $question, $bytes ) = @_;
     my $data;
     $bytes ||= 2;
 
-    say unpack("H*",$question);
-    $self->_connection->write( $question );
-    $self->_connection->read($data, $bytes);
+    say unpack( "H*", $question );
+    $self->_connection->write($question);
+    $self->_connection->read( $data, $bytes );
 
     return $data;
 }
@@ -80,3 +68,46 @@ no Moo;
 __PACKAGE__->meta->make_immutable;
 
 1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Printer::ESCPOS::Connections::Network - Network Connection Interface for L<Printer::ESCPOS>
+
+=head1 VERSION
+
+version 1.006
+
+=head1 ATTRIBUTES
+
+=head2 deviceIP
+
+Contains the IP address of the device when its a network printer. The module creates IO:Socket::INET object to connect
+to the printer. This can be passed in the constructor.
+
+=head2 devicePort
+
+Contains the network port of the device when its a network printer. The module creates IO:Socket::INET object to connect
+to the printer. This can be passed in the constructor.
+
+=head1 METHODS
+
+=head2 read
+
+Read Data from the printer
+
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Printer/ESCPOS/Connections/Serial.pm
+++ b/lib/Printer/ESCPOS/Connections/Serial.pm
@@ -93,34 +93,6 @@ sub write {
     return $bytes_sent;
 }
 
-#sub print {
-#    my ( $self, $raw ) = @_;
-#    my @chunks;
-#
-#    my $buffer = $self->_buffer;
-#    if ( defined $raw ) {
-#        $buffer = $raw;
-#    }
-#    else {
-#        $self->_buffer('');
-#    }
-#
-#    my $n = 8;    # Size of each chunk in bytes
-#    $n = 64 if ( $self->serialOverUSB );
-#
-#    @chunks = unpack "a$n" x ( ( length($buffer) / $n ) - 1 ) . "a*", $buffer;
-#    for my $chunk (@chunks) {
-#        $self->_connection->write($chunk);
-#        if ( $self->serialOverUSB ) {
-#            $self->_connection->read();
-#        }
-#        else {
-#            usleep(10000)
-#              ; # Serial Port is annoying, it doesn't tell you when it is ready to get the next chunk
-#        }
-#    }
-#}
-
 no Moo;
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/Printer/ESCPOS/Connections/Serial.pm
+++ b/lib/Printer/ESCPOS/Connections/Serial.pm
@@ -5,8 +5,15 @@ package Printer::ESCPOS::Connections::Serial;
 
 # PODNAME: Printer::ESCPOS::Connections::Serial
 # ABSTRACT: Serial Connection Interface for L<Printer::ESCPOS> (supports status commands)
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 # Dependencies
 
@@ -17,122 +24,163 @@ with 'Printer::ESCPOS::Roles::Connection';
 use Device::SerialPort;
 use Time::HiRes qw(usleep);
 
-=attr deviceFilePath
 
-This variable contains the path for the printer device file like '/dev/ttyS0' when connected as a serial device on
-UNIX-like systems. For Windows this will be the serial port name like 'COM1', 'COM2' etc. This must be passed in the
-constructor. I haven't tested this on windows, so if you are able to use serial port successfully on windows, drop me a
-email to let me know that I got it right :)
+has deviceFilePath => ( is => 'ro', );
 
-=cut
-
-has deviceFilePath => (
-    is  => 'ro',
-);
-
-=attr baudrate
-
-When used as a local serial device you can set the baudrate of the printer too. Default (38400) will usually work, but
-not always.This param may be specified when creating printer object to make sure it works properly.
-
-$printer = Printer::Thermal->new(deviceFilePath => '/dev/ttyACM0', baudrate => 9600);
-
-=cut
 
 has baudrate => (
     is      => 'ro',
     default => 38400,
 );
 
-=attr readConstTime
-
-Seconds per unfulfilled read call, default 150
-
-=cut
 
 has readConstTime => (
     is      => 'ro',
     default => 150,
 );
 
-=attr serialOverUSB
-
-Set this value to 1 if you are connecting your printer using the USB Cable but it shows up as a serial device
-
-=cut
 
 has serialOverUSB => (
-  is      => 'rw',
-  default => '0',
+    is      => 'rw',
+    default => '0',
 );
 
 has _connection => (
-    is         => 'lazy',
-    init_arg   => undef,
+    is       => 'lazy',
+    init_arg => undef,
 );
 
 sub _build__connection {
     my ($self) = @_;
 
     my $printer = new Device::SerialPort( $self->deviceFilePath )
-        || die "Can't open Port: $!\n";
+      || die "Can't open Port: $!\n";
     $printer->baudrate( $self->baudrate );
-    $printer->read_const_time( $self->readConstTime ); # 1 second per unfulfilled "read" call
-    $printer->read_char_time( 0 );     # don't wait for each character
+    $printer->read_const_time( $self->readConstTime )
+      ;    # 1 second per unfulfilled "read" call
+    $printer->read_char_time(0);    # don't wait for each character
 
     return $printer;
 }
 
-=method read
-
-Read Data from the printer
-
-=cut
 
 sub read {
     my ( $self, $question, $bytes ) = @_;
     $bytes |= 1024;
 
-    $self->_connection->write( $question );
-    my ( $count, $data ) = $self->_connection->read( $bytes );
+    $self->_connection->write($question);
+    my ( $count, $data ) = $self->_connection->read($bytes);
 
     return $data;
 }
 
-=method print
-
-Sends buffer data to the printer.
-
-=cut
-
-sub print {
-    my ( $self, $raw ) = @_;
-    my @chunks;
-
-    my $buffer = $self->_buffer;
-    if( defined $raw ) {
-        $buffer = $raw;
-    } else {
-        $self->_buffer('');
+sub write {
+    my ( $self, $chunk ) = @_;
+    
+    # Send the data through the serial port handle
+    my $bytes_sent = $self->_connection->write($chunk);
+    
+    # Handle the "Serial is Annoying" timing logic
+    if ( $self->serialOverUSB ) {
+        # Serial-over-USB usually needs a handshake/clearance
+        $self->_connection->read(); 
     }
-
-    my $n      = 8;                # Size of each chunk in bytes
-    $n = 64 if ( $self->serialOverUSB );
-
-    @chunks = unpack "a$n" x ( ( length($buffer) / $n ) - 1 ) . "a*", $buffer;
-    for my $chunk (@chunks) {
-        $self->_connection->write($chunk);
-        if ( $self->serialOverUSB ) {
-            $self->_connection->read();
-        }
-        else {
-            usleep(10000)
-              ; # Serial Port is annoying, it doesn't tell you when it is ready to get the next chunk
-        }
+    else {
+        # Standard hardware serial needs a breather between chunks
+        usleep(10000); 
     }
+    
+    return $bytes_sent;
 }
+
+#sub print {
+#    my ( $self, $raw ) = @_;
+#    my @chunks;
+#
+#    my $buffer = $self->_buffer;
+#    if ( defined $raw ) {
+#        $buffer = $raw;
+#    }
+#    else {
+#        $self->_buffer('');
+#    }
+#
+#    my $n = 8;    # Size of each chunk in bytes
+#    $n = 64 if ( $self->serialOverUSB );
+#
+#    @chunks = unpack "a$n" x ( ( length($buffer) / $n ) - 1 ) . "a*", $buffer;
+#    for my $chunk (@chunks) {
+#        $self->_connection->write($chunk);
+#        if ( $self->serialOverUSB ) {
+#            $self->_connection->read();
+#        }
+#        else {
+#            usleep(10000)
+#              ; # Serial Port is annoying, it doesn't tell you when it is ready to get the next chunk
+#        }
+#    }
+#}
 
 no Moo;
 __PACKAGE__->meta->make_immutable;
 
 1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Printer::ESCPOS::Connections::Serial - Serial Connection Interface for L<Printer::ESCPOS> (supports status commands)
+
+=head1 VERSION
+
+version 1.006
+
+=head1 ATTRIBUTES
+
+=head2 deviceFilePath
+
+This variable contains the path for the printer device file like '/dev/ttyS0' when connected as a serial device on
+UNIX-like systems. For Windows this will be the serial port name like 'COM1', 'COM2' etc. This must be passed in the
+constructor. I haven't tested this on windows, so if you are able to use serial port successfully on windows, drop me a
+email to let me know that I got it right :)
+
+=head2 baudrate
+
+When used as a local serial device you can set the baudrate of the printer too. Default (38400) will usually work, but
+not always.This param may be specified when creating printer object to make sure it works properly.
+
+$printer = Printer::Thermal->new(deviceFilePath => '/dev/ttyACM0', baudrate => 9600);
+
+=head2 readConstTime
+
+Seconds per unfulfilled read call, default 150
+
+=head2 serialOverUSB
+
+Set this value to 1 if you are connecting your printer using the USB Cable but it shows up as a serial device
+
+=head1 METHODS
+
+=head2 read
+
+Read Data from the printer
+
+=head2 print
+
+Sends buffer data to the printer.
+
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Printer/ESCPOS/Connections/USB.pm
+++ b/lib/Printer/ESCPOS/Connections/USB.pm
@@ -5,8 +5,15 @@ package Printer::ESCPOS::Connections::USB;
 
 # PODNAME: Printer::ESCPOS::Connections::USB
 # ABSTRACT: USB Connection Interface for L<Printer::ESCPOS>
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 # Dependencies
 
@@ -17,33 +24,18 @@ with 'Printer::ESCPOS::Roles::Connection';
 use Device::USB;
 use Time::HiRes qw(usleep);
 
-=attr vendorId
-
-USB Printers VendorId. use lsusb command to get this value
-
-=cut
 
 has vendorId => (
-    is         => 'ro',
+    is       => 'ro',
     required => 1,
 );
 
-=attr productId
-
-USB Printers product Id. use lsusb command to get this value
-
-=cut
 
 has productId => (
-    is         => 'ro',
+    is       => 'ro',
     required => 1,
 );
 
-=attr endPoint
-
-USB endPoint to write to.
-
-=cut
 
 has endPoint => (
     is       => 'ro',
@@ -51,11 +43,6 @@ has endPoint => (
     default  => 0x01,
 );
 
-=attr timeout
-
-Timeout for bulk write functions for the USB printer.
-
-=cut
 
 has timeout => (
     is       => 'ro',
@@ -64,8 +51,8 @@ has timeout => (
 );
 
 has _connection => (
-    is         => 'lazy',
-    init_arg   => undef,
+    is       => 'lazy',
+    init_arg => undef,
 );
 
 sub _build__connection {
@@ -74,7 +61,7 @@ sub _build__connection {
     my $usb = Device::USB->new();
     my $device = $usb->find_device( $self->vendorId, $self->productId );
 
-    if( $device->get_driver_np(0) ) {
+    if ( $device->get_driver_np(0) ) {
         $device->detach_kernel_driver_np();
     }
     $device->open();
@@ -83,47 +70,53 @@ sub _build__connection {
     return $device;
 }
 
-=method read
-
-Read Data from the printer
-
-=cut
 
 sub read {
     my ( $self, $question, $bytes ) = @_;
     my $data;
     $bytes |= 1024;
 
-    $self->_connection->bulk_write( $self->endPoint, $question, $self->timeout );
-    $self->_connection->bulk_read( $self->endPoint, $data, $bytes, $self->timeout );
+    $self->_connection->bulk_write( $self->endPoint, $question,
+        $self->timeout );
+    $self->_connection->bulk_read( $self->endPoint, $data, $bytes,
+        $self->timeout );
 
     return $data;
 }
 
-=method print
-
-Sends buffer data to the printer.
-
-=cut
-
 sub print {
-    my ( $self, $raw ) = @_;
-    my @chunks;
+    my ($self, $chunk) = @_;
 
-    my $buffer = $self->_buffer;
-    if( defined $raw ) {
-        $buffer = $raw;
-    } else {
-        $self->_buffer('');
-    }
-
-    my $n = 2**14;    # Size of each chunk in bytes
-    @chunks = unpack "a$n" x ( ( length($buffer) / $n ) - 1 ) . "a*", $buffer;
-    for my $chunk (@chunks) {
-        $self->_connection->bulk_write($self->endPoint, $chunk, $self->timeout);
-        usleep(10000);    # USB Port is sometimes annoying, it doesn't always tell you when it is ready to get the next chunk
-    }
+    my $sent = $self->_connection->bulk_write(
+        $self->endPoint,
+        $chunk,
+        $self->timeout
+    );
+    usleep(10000);
+    return $sent;
 }
+
+#sub print {
+#    my ( $self, $raw ) = @_;
+#    my @chunks;
+#
+#    my $buffer = $self->_buffer;
+#    if ( defined $raw ) {
+#        $buffer = $raw;
+#    }
+#    else {
+#        $self->_buffer('');
+#    }
+#
+#    my $n = 2**14;    # Size of each chunk in bytes
+#    @chunks = unpack "a$n" x ( ( length($buffer) / $n ) - 1 ) . "a*", $buffer;
+#    for my $chunk (@chunks) {
+#        $self->_connection->bulk_write( $self->endPoint, $chunk,
+#            $self->timeout );
+#        usleep(10000)
+#          ; # USB Port is sometimes annoying, it doesn't always tell you when it is ready to get the next chunk
+#    }
+#}
 
 no Moo;
 __PACKAGE__->meta->make_immutable;
@@ -132,51 +125,98 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
-=begin wikidoc
+=pod
 
-= SYNOPSIS
+=head1 NAME
+
+Printer::ESCPOS::Connections::USB - USB Connection Interface for L<Printer::ESCPOS>
+
+=head1 VERSION
+
+version 1.006
+
+=head1 SYNOPSIS
 
 For using the printer in USB mode you will need to get a few details for your printer.
 
-retrieve the ~vendorId~ and ~productId~ params using the lsusb command
+retrieve the I<vendorId> and I<productId> params using the lsusb command
 
-    shantanu@shantanu-G41M-ES2L:~$ lsusb
-    Bus 002 Device 002: ID 8087:8000 Intel Corp.
-    Bus 002 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
-    Bus 001 Device 002: ID 8087:8008 Intel Corp.
-    Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
-    Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
-    Bus 003 Device 020: ID 05e0:1200 Symbol Technologies Bar Code Scanner
-    Bus 003 Device 005: ID 413c:2111 Dell Computer Corp.
-    Bus 003 Device 004: ID 046d:c03e Logitech, Inc. Premium Optical Wheel Mouse (M-BT58)
-    Bus 003 Device 009: ID 1cbe:0002 Luminary Micro Inc.
-    Bus 003 Device 007: ID 0cf3:0036 Atheros Communications, Inc.
-    Bus 003 Device 008: ID 1504:0006
-    Bus 003 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+     shantanu@shantanu-G41M-ES2L:~$ lsusb
+     Bus 002 Device 002: ID 8087:8000 Intel Corp.
+     Bus 002 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+     Bus 001 Device 002: ID 8087:8008 Intel Corp.
+     Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+     Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+     Bus 003 Device 020: ID 05e0:1200 Symbol Technologies Bar Code Scanner
+     Bus 003 Device 005: ID 413c:2111 Dell Computer Corp.
+     Bus 003 Device 004: ID 046d:c03e Logitech, Inc. Premium Optical Wheel Mouse (M-BT58)
+     Bus 003 Device 009: ID 1cbe:0002 Luminary Micro Inc.
+     Bus 003 Device 007: ID 0cf3:0036 Atheros Communications, Inc.
+     Bus 003 Device 008: ID 1504:0006
+     Bus 003 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
 
 My printer shows up at the second to last line in the list.
 
-    Bus 003 Device 008: ID 1504:0006
+     Bus 003 Device 008: ID 1504:0006
 
-The ~vendorId~ and ~productId~ for my printer is 0x1504 and 0x0006 respectively
+The I<vendorId> and I<productId> for my printer is 0x1504 and 0x0006 respectively
 
-Now to get the ~endPoint~ value for my printer I use this command:
+Now to get the I<endPoint> value for my printer I use this command:
 
-    shantanu@shantanu-G41M-ES2L:~/test$ sudo lsusb -vvv -d 1504:0006 | grep bEndpointAddress | grep OUT
-            bEndpointAddress     0x01  EP 1 OUT
+     shantanu@shantanu-G41M-ES2L:~/test$ sudo lsusb -vvv -d 1504:0006 | grep bEndpointAddress | grep OUT
+             bEndpointAddress     0x01  EP 1 OUT
 
 The endpoint address is 0x01 which is the default for the module.
 
 Now you have all the values you need for your printer to work in USB mode.
 
-    $device = Printer::ESCPOS->new(
-        driverType => 'USB',
-        vendorId   => 0x1504,
-        productId  => 0x0006,
-        endPoint   => 0x01,   # There is no need to specify endPOint in
-                              # this case as 0x01 is the default value
-    );
-    $device->printer->text("Blah Blah\n");
-    $device->printer->print();
+     $device = Printer::ESCPOS->new(
+         driverType => 'USB',
+         vendorId   => 0x1504,
+         productId  => 0x0006,
+         endPoint   => 0x01,   # There is no need to specify endPOint in
+                               # this case as 0x01 is the default value
+     );
+     $device->printer->text("Blah Blah\n");
+     $device->printer->print();
 
-=end wikidoc
+=head1 ATTRIBUTES
+
+=head2 vendorId
+
+USB Printers VendorId. use lsusb command to get this value
+
+=head2 productId
+
+USB Printers product Id. use lsusb command to get this value
+
+=head2 endPoint
+
+USB endPoint to write to.
+
+=head2 timeout
+
+Timeout for bulk write functions for the USB printer.
+
+=head1 METHODS
+
+=head2 read
+
+Read Data from the printer
+
+=head2 print
+
+Sends buffer data to the printer.
+
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Printer/ESCPOS/Connections/USB.pm
+++ b/lib/Printer/ESCPOS/Connections/USB.pm
@@ -96,28 +96,6 @@ sub print {
     return $sent;
 }
 
-#sub print {
-#    my ( $self, $raw ) = @_;
-#    my @chunks;
-#
-#    my $buffer = $self->_buffer;
-#    if ( defined $raw ) {
-#        $buffer = $raw;
-#    }
-#    else {
-#        $self->_buffer('');
-#    }
-#
-#    my $n = 2**14;    # Size of each chunk in bytes
-#    @chunks = unpack "a$n" x ( ( length($buffer) / $n ) - 1 ) . "a*", $buffer;
-#    for my $chunk (@chunks) {
-#        $self->_connection->bulk_write( $self->endPoint, $chunk,
-#            $self->timeout );
-#        usleep(10000)
-#          ; # USB Port is sometimes annoying, it doesn't always tell you when it is ready to get the next chunk
-#    }
-#}
-
 no Moo;
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/Printer/ESCPOS/Manual.pm
+++ b/lib/Printer/ESCPOS/Manual.pm
@@ -5,405 +5,440 @@ package Printer::ESCPOS::Manual;
 
 # PODNAME: Printer::ESCPOS::Manual
 # ABSTRACT: Manual for Printing POS Receipts using L<Printer::ESCPOS>
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 1;
 
 __END__
 
-=begin wikidoc
+=pod
 
-= SYNOPSIS
+=head1 NAME
 
-== BASIC USAGE
+Printer::ESCPOS::Manual - Manual for Printing POS Receipts using L<Printer::ESCPOS>
 
-    use Printer::ESCPOS;
+=head1 VERSION
 
-    # Create a Printer object, Initialize the printer.
-    my $device = Printer::ESCPOS->new(
-        driverType     => 'Serial'
-        deviceFilePath => '/dev/ttyACM0'
-    );
+version 1.006
 
-    # All Printers have their own initialization
-    # recommendations(Cleaning buffers etc.). Run
-    # this command to let the module do this for you.
-    $device->printer->init();
+=head1 SYNOPSIS
 
+=head2 BASIC USAGE
 
-    # Prepare some data to send to the printer using
-    # formatting and text commands
-    $device->printer->bold(1);
-    $device->printer->text("Heading text\n");
-    $device->printer->bold(0);
-    $device->printer->text("Content here\n");
-    $device->printer->text(". . .\n");
+     use Printer::ESCPOS;
+ 
+     # Create a Printer object, Initialize the printer.
+     my $device = Printer::ESCPOS->new(
+         driverType     => 'Serial'
+         deviceFilePath => '/dev/ttyACM0'
+     );
+ 
+     # All Printers have their own initialization
+     # recommendations(Cleaning buffers etc.). Run
+     # this command to let the module do this for you.
+     $device->printer->init();
+ 
+ 
+     # Prepare some data to send to the printer using
+     # formatting and text commands
+     $device->printer->bold(1);
+     $device->printer->text("Heading text\n");
+     $device->printer->bold(0);
+     $device->printer->text("Content here\n");
+     $device->printer->text(". . .\n");
+ 
+ 
+     # Add a cut paper command at the end to cut the receipt
+     # This command will be ignored by your printer if it
+     # doesn't have a paper cutter on it
+     $device->printer->cutPaper();
+ 
+ 
+     # Send the Prepared data to the printer.
+     $device->printer->print();
 
+=head1 PRINTING TO YOUR PRINTER IN THREE STEPS
 
-    # Add a cut paper command at the end to cut the receipt
-    # This command will be ignored by your printer if it
-    # doesn't have a paper cutter on it
-    $device->printer->cutPaper();
+L<Printer::ESCPOS> uses a three step mechanism for sending the data to the Printer i.e initialization, preparation of data to send to the printer, and finally sending the prepared data to the printer. Separation of preparation and printing steps allows L<Printer::ESCPOS> to deal with communication speed and buffer limitations found in most common ESCPOS printers.
 
+=head2 INITIALIZATION
 
-    # Send the Prepared data to the printer.
-    $device->printer->print();
+=head3 USB PRINTER
 
-= PRINTING TO YOUR PRINTER IN THREE STEPS
+The B<USB> I<driverType> allows you to talk to a printer using its vendorId and productId as params.
 
-[Printer::ESCPOS] uses a three step mechanism for sending the data to the Printer i.e initialization, preparation of data to send to the printer, and finally sending the prepared data to the printer. Separation of preparation and printing steps allows [Printer::ESCPOS] to deal with communication speed and buffer limitations found in most common ESCPOS printers.
-
-== INITIALIZATION
-
-=== USB PRINTER
-
-The *USB* ~driverType~ allows you to talk to a printer using its vendorId and productId as params.
-
-    my $device = Printer::ESCPOS->new(
-        driverType => 'USB',
-        vendorId   => 0x1504,
-        productId  => 0x0006,
-    );
+     my $device = Printer::ESCPOS->new(
+         driverType => 'USB',
+         vendorId   => 0x1504,
+         productId  => 0x0006,
+     );
 
 Optional parameters:
 
-The driver uses a default ~endPoint~ value of 0x01. To get valid values for ~endPoint~ for your printer use the following command:
+The driver uses a default I<endPoint> value of 0x01. To get valid values for I<endPoint> for your printer use the following command:
 
-    shantanu@shantanu-G41M-ES2L:~$ sudo lsusb -vvv -d 1504:0006 | grep bEndpointAddress | grep OUT
-            bEndpointAddress     0x01  EP 1 OUT
+     shantanu@shantanu-G41M-ES2L:~$ sudo lsusb -vvv -d 1504:0006 | grep bEndpointAddress | grep OUT
+             bEndpointAddress     0x01  EP 1 OUT
 
 Replace 1504:0006 with your own printer's vendor id and product id in the above command
 
-    my $device = Printer::ESCPOS->new(
-        driverType => 'USB',
-        vendorId   => 0x1504,
-        productId  => 0x0006,
-        endPoint   => 0x01,
-    );
+     my $device = Printer::ESCPOS->new(
+         driverType => 'USB',
+         vendorId   => 0x1504,
+         productId  => 0x0006,
+         endPoint   => 0x01,
+     );
 
 You may also specify USB device timeout, although default value(1000 ms) should be sufficient in most cases:
 
-    my $device = Printer::ESCPOS->new(
-        driverType => 'USB',
-        vendorId   => 0x1504,
-        productId  => 0x0006,
-        endPoint   => 0x01,
-        timeout    => 500,
-    );
+     my $device = Printer::ESCPOS->new(
+         driverType => 'USB',
+         vendorId   => 0x1504,
+         productId  => 0x0006,
+         endPoint   => 0x01,
+         timeout    => 500,
+     );
 
-=== SERIAL PRINTER
+=head3 SERIAL PRINTER
 
-The Mandatory parameters for a *Serial* ~driverType~ are ~driverType~( *Serial* ) and ~deviceFilePath~
-This is the preferred ~driverType~ for connecting to a printer. This connection type is valid for printers connected over serial ports or for printers connected on physical USB ports but showing up as *Serial* devices(check syslog when you connect the printer). Note that not all printers show up as Serial devices when connected on USB port.
+The Mandatory parameters for a B<Serial> I<driverType> are I<driverType>( B<Serial> ) and I<deviceFilePath>
+This is the preferred I<driverType> for connecting to a printer. This connection type is valid for printers connected over serial ports or for printers connected on physical USB ports but showing up as B<Serial> devices(check syslog when you connect the printer). Note that not all printers show up as Serial devices when connected on USB port.
 
-    my $device = Printer::ESCPOS->new(
-        driverType     => 'Serial',
-        deviceFilePath => '/dev/ttyACM0',
-    );
+     my $device = Printer::ESCPOS->new(
+         driverType     => 'Serial',
+         deviceFilePath => '/dev/ttyACM0',
+     );
 
 Optional parameters:
 
-the driver uses 38400 as default baudrate. If necessary you can change this value by providing a ~baudrate~ parameter.
+the driver uses 38400 as default baudrate. If necessary you can change this value by providing a I<baudrate> parameter.
 
-    my $device = Printer::ESCPOS->new(
-        driverType     => 'Serial',
-        deviceFilePath => '/dev/ttyACM0',
-        baudrate       => 9600,
-    );
+     my $device = Printer::ESCPOS->new(
+         driverType     => 'Serial',
+         deviceFilePath => '/dev/ttyACM0',
+         baudrate       => 9600,
+     );
 
-If your printer is not printing properly when connected on physical serial port try setting the flag ~serialOverUSB~ to
-*0* to tell [Printer::ESCPOS] to use special buffer management optimizations for physical serial ports
+If your printer is not printing properly when connected on physical serial port try setting the flag I<serialOverUSB> to
+B<0> to tell L<Printer::ESCPOS> to use special buffer management optimizations for physical serial ports
 
-    my $device = Printer::ESCPOS->new(
-        driverType     => 'Serial',
-        deviceFilePath => '/dev/ttyACM0',
-        baudrate       => 9600,
-        serialOverUSB  => 0
-    );
+     my $device = Printer::ESCPOS->new(
+         driverType     => 'Serial',
+         deviceFilePath => '/dev/ttyACM0',
+         baudrate       => 9600,
+         serialOverUSB  => 0
+     );
 
-=== NETWORK PRINTER
+=head3 NETWORK PRINTER
 
-The Mandatory parameters for a *Network* ~driverType~ are ~driverType~( *Network* ), ~deviceIP~ and ~devicePort~
-This is a ~driverType~ for printers connected over a network.
+The Mandatory parameters for a B<Network> I<driverType> are I<driverType>( B<Network> ), I<deviceIP> and I<devicePort>
+This is a I<driverType> for printers connected over a network.
 
-    my $device = Printer::ESCPOS->new(
-        driverType => 'Network',
-        deviceIP   => '10.0.13.108',
-        devicePort => '9100',
-    );
+     my $device = Printer::ESCPOS->new(
+         driverType => 'Network',
+         deviceIP   => '10.0.13.108',
+         devicePort => '9100',
+     );
 
+=head3 BASIC DEVICE FILE Driver
 
-=== BASIC DEVICE FILE Driver
-
-The Mandatory parameters for a *File* ~driverType~ are ~driverType~( *File* ) and ~deviceFilePath~
+The Mandatory parameters for a B<File> I<driverType> are I<driverType>( B<File> ) and I<deviceFilePath>
 This Driver is included for those instances when your printing needs are simple(You don't want to check the printer for
-printer status etc. and are only interested in pushing data to the printer for printing) and *Serial* driver type is
-just refusing to work altogether. In this ~driverType~ the data is written directly to the printer device file and from
+printer status etc. and are only interested in pushing data to the printer for printing) and B<Serial> driver type is
+just refusing to work altogether. In this I<driverType> the data is written directly to the printer device file and from
 there sent to the printer. This is the basic text method for ESCPOS printers and it almost always works but it doesn't
-allow you to read Printer Status which might not be a deal breaker for most people. This ~driverType~ can also be used
+allow you to read Printer Status which might not be a deal breaker for most people. This I<driverType> can also be used
 for Printers which connect on USB ports but don't show up as Serial devices in syslog
 
-    my $device = Printer::ESCPOS->new(
-        driverType     => 'File',
-        deviceFilePath => '/dev/usb/lp0',
-    );
+     my $device = Printer::ESCPOS->new(
+         driverType     => 'File',
+         deviceFilePath => '/dev/usb/lp0',
+     );
 
-== PREPARING FORMATTED TEXT FOR PRINTER
+=head2 PREPARING FORMATTED TEXT FOR PRINTER
 
-In all the methods described below its assumed that variable {$device} has been initialized using the appropriate
+In all the methods described below its assumed that variable C<<< $device >>> has been initialized using the appropriate
 connection to the printer with one of the driverTypes mentioned above.
 The following methods prepare the text and text formatting data to be sent to the printer.
 
-=== qr
+=head3 qr
 
-Prints a qr code to the printer. In Generic profile, this creates a QR Code image using L<GD::Barcode::QRcode>. A native
+Prints a qr code to the printer. In Generic profile, this creates a QR Code image using LE<lt>GD::Barcode::QRcodeE<gt>. A native
 implementation may be created using a printer model specific profile.
 
-    $device->printer->qr('Print this QR Code');
-    $device->printer->qr('WIFI:T:WPA;S:ShantanusWifi;P:wifipasswordhere;;')  # Create a QR code for connecting to a Wifi
+     $device->printer->qr('Print this QR Code');
+     $device->printer->qr('WIFI:T:WPA;S:ShantanusWifi;P:wifipasswordhere;;')  # Create a QR code for connecting to a Wifi
 
 You may also pass in optional QR Code format parameters like Ecc, Version and moduleSize. Read more about these params
-at [http://www.qrcode.com/en/about/version.html].
+at L<http://www.qrcode.com/en/about/version.html>.
 
-    my $ecc = 'L'; # Default value
-    my $version = 5; # Default value
-    my $moduleSize = 3; # Default value
-    $device->printer->qr("Don't Panic!", $ecc, $version, $moduleSize);
+     my $ecc = 'L'; # Default value
+     my $version = 5; # Default value
+     my $moduleSize = 3; # Default value
+     $device->printer->qr("Don't Panic!", $ecc, $version, $moduleSize);
 
 You may also call align() before calling qr() to set alignment on the page.
 
-=== utf8ImagedText
+=head3 utf8ImagedText
 
-    use utf8;
-
-    $device->printer->utf8ImagedText("Hello World",
-      fontFamily => "Rubik",
-      fontStyle => "Normal",
-      fontSize => 25,
-      lineHeight => 40
-    );
+     use utf8;
+ 
+     $device->printer->utf8ImagedText("Hello World",
+       fontFamily => "Rubik",
+       fontStyle => "Normal",
+       fontSize => 25,
+       lineHeight => 40
+     );
 
 This method uses native fonts to print utf8 compatible characters including international wide characters. This method
 is slower than direct text printing but it allows exceptional styling options allowing you to print text using system
 fonts in a wide range of font sizes and styles with many more choices than what a thermal printer otherwise provides.
 
-In the background this function uses [Pango] and [Cairo] libraries to create a one line image from a given font styles,
+In the background this function uses L<Pango> and L<Cairo> libraries to create a one line image from a given font styles,
 font family in a given font size. Note that you must not use this method to print more than a single line at a time.
 When you want to print the next line call this method again to print to the next line.
 
-~string~: String to be printed in the line.
+I<string>: String to be printed in the line.
 
-~fontFamily~ (optional, default *'Purisa'*): Font family to use. On linux systems with font config installed use the
+I<fontFamily> (optional, default B<'Purisa'>): Font family to use. On linux systems with font config installed use the
 following command to choose from the list of available fonts:
 
-    fc-list | sed 's/.*:\(.*,\|\s\)\(.*\):.*/\2/'
+     fc-list | sed 's/.*:\(.*,\|\s\)\(.*\):.*/\2/'
 
-You may also install more fonts from https://fonts.google.com/ to your system fonts( copy the font to /usr/share/fonts )
+You may also install more fonts from https:E<sol>E<sol>fonts.google.comE<sol> to your system fonts( copy the font to E<sol>usrE<sol>shareE<sol>fonts )
 
-~fontStyle~ (optional, default *'Normal'*): Font style like Bold, Normal, Italic etc.
+I<fontStyle> (optional, default B<'Normal'>): Font style like Bold, Normal, Italic etc.
 
-~fontSize~ (optional, default *20*): Font size
+I<fontSize> (optional, default B<20>): Font size
 
-~lineHeight~ (optional, default *42*): Line Height in pixels, make sure this is bigger than the font height in pixels for your chosen font size.
+I<lineHeight> (optional, default B<42>): Line Height in pixels, make sure this is bigger than the font height in pixels for your chosen font size.
 
-~paperWidth~ (optional, default *500*): This is set to 500 pixels by default as this is the most common width for receipt printers. Change this
+I<paperWidth> (optional, default B<500>): This is set to 500 pixels by default as this is the most common width for receipt printers. Change this
 as per your printer specs.
 
-=== image
+=head3 image
 
 Prints a GD image object to the printer
 
-    use GD;
+     use GD;
+ 
+     my $img = newFromGif GD::Image('header.gif') || die "Error $!";
+     $device->printer->image($img);
 
-    my $img = newFromGif GD::Image('header.gif') || die "Error $!";
-    $device->printer->image($img);
-
-=== text
+=head3 text
 
 Sends raw text to the printer.
 
-    $device->printer->text("Hello Printer::ESCPOS\n")
+     $device->printer->text("Hello Printer::ESCPOS\n")
 
-=== printAreaWidth
+=head3 printAreaWidth
 
-Sets the Print area width specified by width which is a int between *0* to *65535*
+Sets the Print area width specified by width which is a int between B<0> to B<65535>
 
-    $device->printer->printAreaWidth( 255 );
+     $device->printer->printAreaWidth( 255 );
 
 Note: If you are using Printer::ESCPOS version prior to v1.* Please check documentation for older version of this module
 the nL and nH syntax for this method.
 
-=== tabPositions
+=head3 tabPositions
 
 Sets horizontal tab positions for tab stops. Upto 32 tab positions can be set in most receipt printers.
 
-    $device->printer->tabPositions( 5, 9, 13 );
+     $device->printer->tabPositions( 5, 9, 13 );
 
-* Default tab positions are usually in intervals of 8 chars (9, 17, 25) etc.
+=over
 
-=== tab
+=item *
 
-moves the cursor to next horizontal tab position like a {"\t"}. This command is ignored unless the next horizontal tab
-position has been set. You may substitute this command with a {"\t"} as well.
+Default tab positions are usually in intervals of 8 chars (9, 17, 25) etc.
 
-This
+=back
 
-    $device->printer->text("blah blah");
-    $device->printer->tab();
-    $device->printer->text("blah2 blah2");
+=head3 tab
 
-is same as this
-
-    $device->printer->text("blah blah\tblah2 blah2");
-
-=== lf
-
-line feed. Moves to the next line. You can substitute this method with {"\n"} in your print or text method e.g. :
+moves the cursor to next horizontal tab position like a C<<< "\t" >>>. This command is ignored unless the next horizontal tab
+position has been set. You may substitute this command with a C<<< "\t" >>> as well.
 
 This
 
-    $device->printer->text("blah blah");
-    $device->printer->lf();
-    $device->printer->text("blah2 blah2");
+     $device->printer->text("blah blah");
+     $device->printer->tab();
+     $device->printer->text("blah2 blah2");
 
 is same as this
 
-    $device->printer->text("blah blah\nblah2 blah2");
+     $device->printer->text("blah blah\tblah2 blah2");
 
-=== font
+=head3 lf
 
-Set Font style, you can pass *a*, *b* or *c*. Many printers don't support style *c* and only have two supported styles.
+line feed. Moves to the next line. You can substitute this method with C<<< "\n" >>> in your print or text method e.g. :
 
-    $device->printer->font('a');
-    $device->printer->text('Writing in Font A');
-    $device->printer->font('b');
-    $device->printer->text('Writing in Font B');
+This
 
-=== bold
+     $device->printer->text("blah blah");
+     $device->printer->lf();
+     $device->printer->text("blah2 blah2");
 
-Set bold mode *0* for off and *1* for on. Also called emphasized mode in some printer manuals
+is same as this
 
-    $device->printer->bold(1);
-    $device->printer->text("This is Bold Text\n");
-    $device->printer->bold(0);
-    $device->printer->text("This is not Bold Text\n");
+     $device->printer->text("blah blah\nblah2 blah2");
 
-=== doubleStrike
+=head3 font
 
-Set double-strike mode *0* for off and *1* for on
+Set Font style, you can pass B<a>, B<b> or B<c>. Many printers don't support style B<c> and only have two supported styles.
 
-    $device->printer->doubleStrike(1);
-    $device->printer->text("This is Double Striked Text\n");
-    $device->printer->doubleStrike(0);
-    $device->printer->text("This is not Double Striked  Text\n");
+     $device->printer->font('a');
+     $device->printer->text('Writing in Font A');
+     $device->printer->font('b');
+     $device->printer->text('Writing in Font B');
 
-=== underline
+=head3 bold
 
-set underline, *0* for off, *1* for on and *2* for double thickness
+Set bold mode B<0> for off and B<1> for on. Also called emphasized mode in some printer manuals
 
-    $device->printer->underline(1);
-    $device->printer->text("This is Underlined Text\n");
-    $device->printer->underline(2);
-    $device->printer->text("This is Underlined Text with thicker underline\n");
-    $device->printer->underline(0);
-    $device->printer->text("This is not Underlined Text\n");
+     $device->printer->bold(1);
+     $device->printer->text("This is Bold Text\n");
+     $device->printer->bold(0);
+     $device->printer->text("This is not Bold Text\n");
 
-=== invert
+=head3 doubleStrike
 
-Reverse white/black printing mode pass *0* for off and *1* for on
+Set double-strike mode B<0> for off and B<1> for on
 
-    $device->printer->invert(1);
-    $device->printer->text("This is Inverted Text\n");
-    $device->printer->invert(0);
-    $device->printer->text("This is not Inverted Text\n");
+     $device->printer->doubleStrike(1);
+     $device->printer->text("This is Double Striked Text\n");
+     $device->printer->doubleStrike(0);
+     $device->printer->text("This is not Double Striked  Text\n");
 
-=== color
+=head3 underline
+
+set underline, B<0> for off, B<1> for on and B<2> for double thickness
+
+     $device->printer->underline(1);
+     $device->printer->text("This is Underlined Text\n");
+     $device->printer->underline(2);
+     $device->printer->text("This is Underlined Text with thicker underline\n");
+     $device->printer->underline(0);
+     $device->printer->text("This is not Underlined Text\n");
+
+=head3 invert
+
+Reverse whiteE<sol>black printing mode pass B<0> for off and B<1> for on
+
+     $device->printer->invert(1);
+     $device->printer->text("This is Inverted Text\n");
+     $device->printer->invert(0);
+     $device->printer->text("This is not Inverted Text\n");
+
+=head3 color
 
 Most thermal printers support just one color, black. Some ESCPOS printers(especially dot matrix) also support a second
 color, usually red. In many models, this only works when the color is set at the beginning of a new line before any text
-is printed. Pass *0* or *1* to switch between the two colors.
+is printed. Pass B<0> or B<1> to switch between the two colors.
 
-    $device->printer->lf();
-    $device->printer->color(0); #black
-    $device->printer->text("black");
-    $device->printer->lf();
-    $device->printer->color(1); #red
-    $device->printer->text("Red");
-    $device->printer->print();
+     $device->printer->lf();
+     $device->printer->color(0); #black
+     $device->printer->text("black");
+     $device->printer->lf();
+     $device->printer->color(1); #red
+     $device->printer->text("Red");
+     $device->printer->print();
 
-=== justify
+=head3 justify
 
-Set Justification. Options *left*, *right* and *center*
+Set Justification. Options B<left>, B<right> and B<center>
 
-    $device->printer->justify( 'right' );
-    $device->printer->text("This is right justified");
+     $device->printer->justify( 'right' );
+     $device->printer->text("This is right justified");
 
-=== upsideDown
+=head3 upsideDown
 
-Sets Upside Down Printing on/off (pass *0* or *1*)
+Sets Upside Down Printing onE<sol>off (pass B<0> or B<1>)
 
-    $device->printer->upsideDown(1);
-    $device->printer->text("This text is upside down");
+     $device->printer->upsideDownPrinting(1);
+     $device->printer->text("This text is upside down");
 
-=== fontHeight
+=head3 fontHeight
 
-Set font height. Only supports *0* or *1* for printmode set to 1, supports values *0*, *1*, *2*, *3*, *4*, *5*, *6* and
-*7* for non-printmode state (default)
+Set font height. Only supports B<0> or B<1> for printmode set to 1, supports values B<0>, B<1>, B<2>, B<3>, B<4>, B<5>, B<6> and
+B<7> for non-printmode state (default)
 
-    $device->printer->fontHeight(1);
-    $device->printer->text("double height\n");
-    $device->printer->fontHeight(2);
-    $device->printer->text("triple height\n");
-    $device->printer->fontHeight(3);
-    $device->printer->text("quadruple height\n");
-    . . .
+     $device->printer->fontHeight(1);
+     $device->printer->text("double height\n");
+     $device->printer->fontHeight(2);
+     $device->printer->text("triple height\n");
+     $device->printer->fontHeight(3);
+     $device->printer->text("quadruple height\n");
+     . . .
 
-=== fontWidth
+=head3 fontWidth
 
-Set font width. Only supports *0* or *1* for printmode set to 1, supports values *0*, *1*, *2*, *3*, *4*, *5*, *6* and
-*7* for non-printmode state (default)
+Set font width. Only supports B<0> or B<1> for printmode set to 1, supports values B<0>, B<1>, B<2>, B<3>, B<4>, B<5>, B<6> and
+B<7> for non-printmode state (default)
 
-    $device->printer->fontWidth(1);
-    $device->printer->text("double width\n");
-    $device->printer->fontWidth(2);
-    $device->printer->text("triple width\n");
-    $device->printer->fontWidth(3);
-    $device->printer->text("quadruple width\n");
-    . . .
+     $device->printer->fontWidth(1);
+     $device->printer->text("double width\n");
+     $device->printer->fontWidth(2);
+     $device->printer->text("triple width\n");
+     $device->printer->fontWidth(3);
+     $device->printer->text("quadruple width\n");
+     . . .
 
-=== charSpacing
+=head3 charSpacing
 
 Sets character spacing. Takes a value between 0 and 255
 
-    $device->printer->charSpacing(5);
-    $device->printer->text("Blah Blah Blah\n");
-    $device->printer->print();
+     $device->printer->charSpacing(5);
+     $device->printer->text("Blah Blah Blah\n");
+     $device->printer->print();
 
-=== lineSpacing
+=head3 lineSpacing
 
 Sets the line spacing i.e the spacing between each line of printout.
 
-    $device->printer->lineSpacing($spacing);
+     $device->printer->lineSpacing($spacing);
 
-* 0 <= $spacing <= 255
+=over
 
-=== selectDefaultLineSpacing
+=item *
+
+0 E<lt>= $spacing E<lt>= 255
+
+=back
+
+=head3 selectDefaultLineSpacing
 
 Reverts to default line spacing for the printer
 
-    $device->printer->selectDefaultLineSpacing();
+     $device->printer->selectDefaultLineSpacing();
 
-=== printPosition
+=head3 printPosition
 
 Sets the distance from the beginning of the line to the position at which characters are to be printed.
 
-    $device->printer->printPosition( $length, $height );
+     $device->printer->printPosition( $length, $height );
 
-* 0 <= $length <= 255
-* 0 <= $height <= 255
+=over
 
-=== leftMargin
+=item *
+
+0 E<lt>= $length E<lt>= 255
+
+=item *
+
+0 E<lt>= $height E<lt>= 255
+
+=back
+
+=head3 leftMargin
 
 Sets the left margin for printing. Set the left margin at the beginning of a line. The printer ignores any data
 preceding this command on the same line in the buffer.
@@ -413,208 +448,288 @@ In page mode sets the left margin to leftMargin x (horizontal motion unit) from 
 Left Margin, range: 0 to 65535. If the margin exceeds the printable area, the left margin is automatically set to the
 maximum value of the printable area.
 
-    $device->printer->leftMargin($leftMargin);
+     $device->printer->leftMargin($leftMargin);
 
-=== rot90
+=head3 rot90
 
 Rotate printout by 90 degrees
 
-    $device->printer->rot90(1);
-    $device->printer->text("This is rotated 90 degrees\n");
-    $device->printer->rot90(0);
-    $device->printer->text("This is not rotated 90 degrees\n");
+     $device->printer->rot90(1);
+     $device->printer->text("This is rotated 90 degrees\n");
+     $device->printer->rot90(0);
+     $device->printer->text("This is not rotated 90 degrees\n");
 
-=== barcode
+=head3 barcode
 
 This method prints a barcode to the printer. This can be bundled with other text formatting commands at the appropriate
-point where you would like to print a barcode on your print out. takes argument ~barcode~ as the barcode value.
+point where you would like to print a barcode on your print out. takes argument I<barcode> as the barcode value.
 
 In the simplest form you can use this command as follows:
 
-    #Default barcode printed in code93 system with a width of 2 and HRI Chars printed below the barcode
-    $device->printer->barcode(
-        barcode     => 'SHANTANU BHADORIA',
-    );
+     #Default barcode printed in code93 system with a width of 2 and HRI Chars printed below the barcode
+     $device->printer->barcode(
+         barcode     => 'SHANTANU BHADORIA',
+     );
 
-However there are several customizations available including barcode ~system~, ~font~, ~height~ etc.
+However there are several customizations available including barcode I<system>, I<font>, I<height> etc.
 
-    my $hripos = 'above';
-    my $font   = 'a';
-    my $height = 100;
-    my $system = 'UPC-A';
-    $device->printer->barcode(
-        HRIPosition => $hripos,        # Position of Human Readable characters
-                                       # 'none','above','below','aboveandbelow'
-        font        => $font,          # Font for HRI characters. 'a' or 'b'
-        height      => $height,        # no of dots in vertical direction
-        system      => $system,        # Barcode system
-        width       => 2               # 2:0.25mm, 3:0.375mm, 4:0.5mm, 5:0.625mm, 6:0.75mm
-        barcode     => '123456789012', # Check barcode system you are using for allowed
-                                       # characters in barcode
-    );
-    $device->printer->barcode(
-        system      => 'CODE39',
-        HRIPosition => 'above',
-        barcode     => '*1-I.I/ $IA*',
-    );
-    $device->printer->barcode(
-        system      => 'CODE93',
-        HRIPosition => 'above',
-        barcode     => 'Shan',
-    );
+     my $hripos = 'above';
+     my $font   = 'a';
+     my $height = 100;
+     my $system = 'UPC-A';
+     $device->printer->barcode(
+         HRIPosition => $hripos,        # Position of Human Readable characters
+                                        # 'none','above','below','aboveandbelow'
+         font        => $font,          # Font for HRI characters. 'a' or 'b'
+         height      => $height,        # no of dots in vertical direction
+         system      => $system,        # Barcode system
+         width       => 2               # 2:0.25mm, 3:0.375mm, 4:0.5mm, 5:0.625mm, 6:0.75mm
+         barcode     => '123456789012', # Check barcode system you are using for allowed
+                                        # characters in barcode
+     );
+     $device->printer->barcode(
+         system      => 'CODE39',
+         HRIPosition => 'above',
+         barcode     => '*1-I.I/ $IA*',
+     );
+     $device->printer->barcode(
+         system      => 'CODE93',
+         HRIPosition => 'above',
+         barcode     => 'Shan',
+     );
 
-Available barcode ~systems~:
+Available barcode I<systems>:
 
-* UPC-A
-* UPC-C
-* JAN13
-* JAN8
-* CODE39
-* ITF
-* CODABAR
-* CODE93
-* CODE128
+=over
 
-=== printNVImage
+=item *
+
+UPC-A
+
+=item *
+
+UPC-C
+
+=item *
+
+JAN13
+
+=item *
+
+JAN8
+
+=item *
+
+CODE39
+
+=item *
+
+ITF
+
+=item *
+
+CODABAR
+
+=item *
+
+CODE93
+
+=item *
+
+CODE128
+
+=back
+
+=head3 printNVImage
 
 Prints bit image stored in Non-Volatile (NV) memory of the printer.
 
-    $device->printer->printNVImage($flag);
+     $device->printer->printNVImage($flag);
 
-* $flag = 0 # Normal width and Normal Height
-* $flag = 1 # Double width and Normal Height
-* $flag = 2 # Normal width and Double Height
-* $flag = 3 # Double width and Double Height
+=over
 
-=== printImage
+=item *
+
+$flag = 0 # Normal width and Normal Height
+
+=item *
+
+$flag = 1 # Double width and Normal Height
+
+=item *
+
+$flag = 2 # Normal width and Double Height
+
+=item *
+
+$flag = 3 # Double width and Double Height
+
+=back
+
+=head3 printImage
 
 Prints bit image stored in Volatile memory of the printer. This image gets erased when printer is reset.
 
-    $device->printer->printImage($flag);
+     $device->printer->printImage($flag);
 
-* $flag = 0 # Normal width and Normal Height
-* $flag = 1 # Double width and Normal Height
-* $flag = 2 # Normal width and Double Height
-* $flag = 3 # Double width and Double Height
+=over
 
-=== cutPaper
+=item *
 
-Cuts the paper, if ~feed~ is set to *0* then printer doesnt feed paper to cutting position before cutting it. The
+$flag = 0 # Normal width and Normal Height
+
+=item *
+
+$flag = 1 # Double width and Normal Height
+
+=item *
+
+$flag = 2 # Normal width and Double Height
+
+=item *
+
+$flag = 3 # Double width and Double Height
+
+=back
+
+=head3 cutPaper
+
+Cuts the paper, if I<feed> is set to B<0> then printer doesnt feed paper to cutting position before cutting it. The
 default behavior is that the printer doesn't feed paper to cutting position before cutting. One pre-requisite line feed
 is automatically executed before paper cut though.
 
-    $device->printer->cutPaper( feed => 0 )
+     $device->printer->cutPaper( feed => 0 )
 
 While not strictly a text formatting option, in receipt printer the cut paper instruction is sent along with the rest of
 the text and text formatting data and the printer cuts the paper at the appropriate points wherever this command is
 used.
 
-=== drawerKickPulse
+=head3 drawerKickPulse
 
 Trigger drawer kick. Used to open cash drawer connected to the printer. In some use cases it may be used to trigger
 other devices by close contact.
 
-    $device->printer->drawerKickPulse( $pin, $time );
+     $device->printer->drawerKickPulse( $pin, $time );
 
-* $pin is either 0( for pin 2 ) and 1( for pin5 ) default value is 0
-* $time is a value between 1 to 8 and the pulse duration in multiples of 100ms. default value is 8
+=over
+
+=item *
+
+$pin is either 0( for pin 2 ) and 1( for pin5 ) default value is 0
+
+=item *
+
+$time is a value between 1 to 8 and the pulse duration in multiples of 100ms. default value is 8
+
+=back
 
 For default values use without any params to kick drawer pin 2 with a 800ms pulse
 
-    $device->printer->drawerKickPulse();
+     $device->printer->drawerKickPulse();
 
 Again like cutPaper command this is obviously not a text formatting command but this command is sent along with the rest
 of the text and text formatting data and the printer sends the pulse at the appropriate points wherever this command is
 used. While originally designed for triggering a cash drawer to open, in practice this port can be used for all sorts of
 devices like pulsing light, or sound alarm etc.
 
-== PRINTING
+=head2 PRINTING
 
-=== print
+=head3 print
 
 Once Initialization is done and the formatted text for printing is prepared using the above commands, its time to send
 these commands to printer. This is a single easy step.
 
-    $device->printer->print();
+     $device->printer->print();
 
 Why an extra print step to send this data to the printer?
 This is necessary because many printers have difficulty handling large amount of print data sent across in a single
-large stream. Separating the preparation of data from transmission of data to the printer allows [Printer::ESCPOS] to do
+large stream. Separating the preparation of data from transmission of data to the printer allows L<Printer::ESCPOS> to do
 some buffer management and optimization in the way the entire data is sent to the printer with tiny timed breaks between
 chunks of data for a reliable printer output.
 
-== GETTING PRINTER HEALTH STATUS
+=head2 GETTING PRINTER HEALTH STATUS
 
-The *Serial* ~driverType~ allows reading of printer health, paper and other status parameters from the printer.
+The B<Serial> I<driverType> allows reading of printer health, paper and other status parameters from the printer.
 At the moment there are following commands available for getting printer status.
 
-=== printerStatus
+=head3 printerStatus
 
 Returns printer status in a hashref.
 
-    return {
-        drawer_pin3_high            => $flags[5],
-        offline                     => $flags[4],
-        waiting_for_online_recovery => $flags[2],
-        feed_button_pressed         => $flags[1],
-    };
+     return {
+         drawer_pin3_high            => $flags[5],
+         offline                     => $flags[4],
+         waiting_for_online_recovery => $flags[2],
+         feed_button_pressed         => $flags[1],
+     };
 
-=== offlineStatus
+=head3 offlineStatus
 
 Returns a hashref for paper cover closed status, feed button pressed status, paper end stop status, and a aggregate
 error status either of which will prevent the printer from processing a printing request.
 
-    return {
-        cover_is_closed     => $flags[5],
-        feed_button_pressed => $flags[4],
-        paper_end           => $flags[2],
-        error               => $flags[1],
-    };
+     return {
+         cover_is_closed     => $flags[5],
+         feed_button_pressed => $flags[4],
+         paper_end           => $flags[2],
+         error               => $flags[1],
+     };
 
-=== errorStatus
+=head3 errorStatus
 
 Returns hashref with error flags for auto_cutter_error, unrecoverable error and auto-recoverable error
 
-    return {
-        auto_cutter_error     => $flags[4],
-        unrecoverable_error   => $flags[2],
-        autorecoverable_error => $flags[1],
-    };
+     return {
+         auto_cutter_error     => $flags[4],
+         unrecoverable_error   => $flags[2],
+         autorecoverable_error => $flags[1],
+     };
 
-=== paperSensorStatus
+=head3 paperSensorStatus
 
 Gets printer paper Sensor status. Returns a hashref with four sensor statuses. Two paper near end sensors and two paper
 end sensors for printers supporting this feature. The exact returned status might differ based on the make of your
 printer. If any of the flags is set to 1 it implies that the paper is out or near end.
 
-    return {
-        paper_roll_near_end_sensor_1 => $flags[5],
-        paper_roll_near_end_sensor_2 => $flags[4],
-        paper_roll_status_sensor_1 => $flags[2],
-        paper_roll_status_sensor_2 => $flags[1],
-    };
+     return {
+         paper_roll_near_end_sensor_1 => $flags[5],
+         paper_roll_near_end_sensor_2 => $flags[4],
+         paper_roll_status_sensor_1 => $flags[2],
+         paper_roll_status_sensor_2 => $flags[1],
+     };
 
-=== inkStatusA
+=head3 inkStatusA
 
 Only available for dot-matrix and other ink consuming printers. Gets printer ink status for inkA(usually black ink).
 Returns a hashref with ink statuses.
 
-    return {
-        ink_near_end          => $flags[5],
-        ink_end               => $flags[4],
-        ink_cartridge_missing => $flags[2],
-        cleaning_in_progress  => $flags[1],
-    };
+     return {
+         ink_near_end          => $flags[5],
+         ink_end               => $flags[4],
+         ink_cartridge_missing => $flags[2],
+         cleaning_in_progress  => $flags[1],
+     };
 
-=== inkStatusB
+=head3 inkStatusB
 
 Only available for dot-matrix and other ink consuming printers. Gets printer ink status for inkB(usually red ink).
 Returns a hashref with ink statuses.
 
-    return {
-        ink_near_end          => $flags[5],
-        ink_end               => $flags[4],
-        ink_cartridge_missing => $flags[2],
-    };
+     return {
+         ink_near_end          => $flags[5],
+         ink_end               => $flags[4],
+         ink_cartridge_missing => $flags[2],
+     };
 
-=end wikidoc
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Printer/ESCPOS/Profiles/Generic.pm
+++ b/lib/Printer/ESCPOS/Profiles/Generic.pm
@@ -44,21 +44,23 @@ use constant {
 sub init {
     my ($self) = @_;
 
-    $self->driver->print( _ESC . '@' );
+    $self->driver->write( _ESC . '@' );
 }
 
 
 sub enable {
     my ( $self, $n ) = @_;
 
+    $n ||= 0;
+
+    confess "Invalid parameter please use '0' or '1'";
+        unless ($n == 1 or $n == 0);
+
     if ( $n == 1 ) {
-        $self->driver->print( _ESC . '=' . chr(1) );
+        $self->driver->write( _ESC . '=' . chr(1) );
     }
-    elsif ( $n == 0 ) {
-        $self->driver->print( _ESC . '=' . chr(2) );
-    }
-    else {
-        confess "Invalid parameter please use '0' or '1'";
+    else ( $n == 0 ) {
+        $self->driver->write( _ESC . '=' . chr(2) );
     }
 }
 
@@ -125,8 +127,8 @@ sub image {
         carp
 'Width is greater than 512 pixels and could be truncated at print time';
     }
-    if ( $img->height > 255 ) {
-        confess 'Height is greater than 255 pixels';
+    if ( $img->height > 65535 ) {
+        confess 'Height is greater than 65535 pixels';
     }
 
     my @padding = $self->_pad_image_size( $img->width );
@@ -179,6 +181,7 @@ sub image {
     $self->_print_image( $pixelLine, \@imageSize );
 }
 
+
 sub _pad_image_size {
     my ( $self, $width ) = @_;
 
@@ -196,40 +199,49 @@ sub _pad_image_size {
     }
 }
 
+
 sub _print_image {
     my ( $self, $pixelLine, $imageSize ) = @_;
 
+    # GS v 0 0 (Raster bit image)
     $self->driver->write( _GS . "v\x30\x00" );
-    my $buffer = sprintf(
-        "%02X%02X%02X%02X",
-        (
-            ( ( $imageSize->[0] / $imageSize->[1] ) / 8 ), 0, $imageSize->[1],
-            0
-        )
-    );
-    $self->driver->write( pack( "H*", $buffer ) );
 
-    $buffer = "";
-    my $i     = 0;
-    my $count = 0;
+    # Calculate xL, xH (Width in bytes) and yL, yH (Height in pixels)
+    my $width_bytes = ( $imageSize->[0] / $imageSize->[1] ) / 8;
+    my $height_px   = $imageSize->[1];
+
+    my $xL = $width_bytes % 256;
+    my $xH = int( $width_bytes / 256 );
+    my $yL = $height_px % 256;
+    my $yH = int( $height_px / 256 );
+
+    # Pack them as 4 hex bytes: xL xH yL yH
+    my $size_buffer = pack( "C4", $xL, $xH, $yL, $yH );
+    $self->driver->write($size_buffer);
+
+    my $buffer = "";
+    my $i      = 0;
+    my $count  = 0;
     while ( $i < length($pixelLine) ) {
         my $octalString = oct( "0b" . substr( $pixelLine, $i, 8 ) );
-        $buffer .= sprintf( "%02X", $octalString );
+        $buffer .= pack( "C", $octalString ); # Use pack C instead of sprintf hex strings
         $i += 8;
         $count++;
-        if ( $count % 4 == 0 ) {
-            $self->driver->write( pack( "H*", $buffer ) );
+        if ( $count % 128 == 0 ) { # Increased flush size for speed
+            $self->driver->write($buffer);
             $buffer = "";
             $count  = 0;
         }
     }
+    $self->driver->write($buffer) if length $buffer;
 }
+
 
 sub printAreaWidth {
     my ( $self, $width ) = @_;
 
     # Set a default width if no width is provided (standard 80mm)
-    $width //= 512;
+    $width ||= 512;
 
     # 1. Validation: Make sure it's defined and looks like a positive integer
     unless ( defined $width && $width =~ /^\d+$/ && $width >= 1 && $width <= 65535 ) {
@@ -242,8 +254,9 @@ sub printAreaWidth {
     my $nL = $width % 256;
 
     # 3. Write: Use our new standard driver 'write' method
-    $self->driver->write( "\x1D" . 'W' . chr($nL) . chr($nH) );
+    $self->driver->write( _GS . 'W' . chr($nL) . chr($nH) );
 }
+
 
 sub tabPositions {
     my ( $self, @positions ) = @_;
@@ -268,9 +281,31 @@ sub tab {
 
 
 sub lf {
-    my ($self) = @_;
+    my ($self, $n) = @_;
+    
+    $n ||= 1;
 
-    $self->driver->write("\n");
+    if ( $n ==1 ) {
+        $self->driver->write("\n");
+        return;
+    }
+
+    # If a number is provided,use ESC d n for multi line feed.
+    # Clamp to 255 to prevent ESC/POS overflow.
+    $n = 255 if $n > 255;
+    $self->driver->write(_ESC . "d" . chr($n));
+}
+
+
+sub dotFeed { 
+    my ($self, $n) = @_;
+
+    $n ||= 1;
+
+    # Same deal as linefeed. We have an option for multi dot feed.
+    # Clamp to 255 to prevent ESC/POS overflow.
+    $n = 255 if $n > 255;
+    $self->driver->write(_ESC . "J" . chr($n));
 }
 
 
@@ -428,7 +463,7 @@ sub fontHeight {
     my $width = $self->widthStatus;
 
     confess
-"Invalid value for fontHeight '$height'. Use a integer between '0' and '7'.
+    "Invalid value for fontHeight '$height'. Use a integer between '0' and '7'.
         Usage: \n\t\$device->printer->fontHeight(5)\n"
       unless ( isint $height >= 0 and $height <= 7 );
 
@@ -641,15 +676,30 @@ sub printImage {
 
 
 sub cutPaper {
-    my ( $self, %params ) = @_;
-    $params{feed} ||= 0;
+    # Try to emulate python escpos library cut feature.
+    my ($self, $mode, $feed) = @_;
+    $mode ||= 'FULL';
+    $feed //= 1; # use //= for the ability to still pass 0.
 
-    $self->lf();
-    if ( $params{feed} == 0 ) {
-        $self->driver->write( _GS . 'V' . chr(1) );
+    # If feed is false, use printer's internal "Function B" (GS V 66 0)
+    if (!$feed) {
+        $self->driver->write(_GS . 'V' . chr(66) . chr(0));
+        return;
+    }
+
+    # If feed is true (Default), manually feed 6 lines and use internal
+    # "Function A".
+    $self->lf(6);
+
+    my $upper_mode = uc($mode);
+    if ( uc($mode) eq 'PART') {
+        $self->driver->write(_GS . 'V' . chr(0));
+    }
+    elsif ($uppermode eq 'FULL') {
+        $self->driver->write(_GS . 'V' . chr(1));
     }
     else {
-        $self->driver->write( _GS . 'V' . chr(66) . chr(0) );
+        confess "Invalid mode '$mode'. Use 'FULL' or 'PART'";
     }
 
 }

--- a/lib/Printer/ESCPOS/Profiles/Generic.pm
+++ b/lib/Printer/ESCPOS/Profiles/Generic.pm
@@ -53,13 +53,13 @@ sub enable {
 
     $n ||= 0;
 
-    confess "Invalid parameter please use '0' or '1'";
+    confess "Invalid parameter please use '0' or '1'"
         unless ($n == 1 or $n == 0);
 
     if ( $n == 1 ) {
         $self->driver->write( _ESC . '=' . chr(1) );
     }
-    else ( $n == 0 ) {
+    elsif ( $n == 0 ) {
         $self->driver->write( _ESC . '=' . chr(2) );
     }
 }
@@ -678,7 +678,8 @@ sub printImage {
 sub cutPaper {
     # Try to emulate python escpos library cut feature.
     my ($self, $mode, $feed) = @_;
-    $mode ||= 'FULL';
+
+    $mode //= 'FULL';
     $feed //= 1; # use //= for the ability to still pass 0.
 
     # If feed is false, use printer's internal "Function B" (GS V 66 0)
@@ -687,15 +688,15 @@ sub cutPaper {
         return;
     }
 
-    # If feed is true (Default), manually feed 6 lines and use internal
+    # If feed is true (Default), manually feed 10 lines and use internal
     # "Function A".
-    $self->lf(6);
+    $self->lf(10);
 
     my $upper_mode = uc($mode);
-    if ( uc($mode) eq 'PART') {
+    if ( $upper_mode eq 'PART') {
         $self->driver->write(_GS . 'V' . chr(0));
     }
-    elsif ($uppermode eq 'FULL') {
+    elsif ($upper_mode eq 'FULL') {
         $self->driver->write(_GS . 'V' . chr(1));
     }
     else {

--- a/lib/Printer/ESCPOS/Profiles/Generic.pm
+++ b/lib/Printer/ESCPOS/Profiles/Generic.pm
@@ -245,21 +245,6 @@ sub printAreaWidth {
     $self->driver->write( "\x1D" . 'W' . chr($nL) . chr($nH) );
 }
 
-#sub printAreaWidth {
-#    my ( $self, $width ) = @_;
-#
-#    confess
-#"Width must be a integer between 0 and 65535 in printAreaWidth(). Invalid value '$width'.
-#        Usage: \n\t\$device->printer->printAreaWidth(\$width)\n"
-#      unless ( isint $width == 1 and $width <= 65535 and $width >= 1 );
-#
-#    my $nH = $width >> 8;
-#    my $nL = $width - ( $nH << 8 );
-#
-#    $self->driver->write( _GS . 'W' . chr($nL) . chr($nH) );
-#}
-
-
 sub tabPositions {
     my ( $self, @positions ) = @_;
     my $pos = '';

--- a/lib/Printer/ESCPOS/Profiles/Generic.pm
+++ b/lib/Printer/ESCPOS/Profiles/Generic.pm
@@ -5,8 +5,15 @@ package Printer::ESCPOS::Profiles::Generic;
 
 # PODNAME: Printer::ESCPOS::Profiles::Generic
 # ABSTRACT: Generic Profile for Printers for L<Printer::ESCPOS>. Most common functions are included here.
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 # Dependencies
 use 5.010;
@@ -25,27 +32,777 @@ use constant {
     _GS  => "\x1d",
     _DLE => "\x10",
     _FS  => "\x1c",
+
     # Level 2 Constants
-    _FF   => "\x0c",
-    _SP   => "\x20",
-    _EOT  => "\x04",
-    _DC4  => "\x14",
+    _FF  => "\x0c",
+    _SP  => "\x20",
+    _EOT => "\x04",
+    _DC4 => "\x14",
 };
 
-=method init
-
-Initializes the Printer. Clears the data in print buffer and resets the printer to the mode that was in effect when the
-power was turned on. This function is automatically called on creation of printer object.
-
-=cut
 
 sub init {
-    my ( $self ) = @_;
+    my ($self) = @_;
 
     $self->driver->print( _ESC . '@' );
 }
 
-=method enable
+
+sub enable {
+    my ( $self, $n ) = @_;
+
+    if ( $n == 1 ) {
+        $self->driver->print( _ESC . '=' . chr(1) );
+    }
+    elsif ( $n == 0 ) {
+        $self->driver->print( _ESC . '=' . chr(2) );
+    }
+    else {
+        confess "Invalid parameter please use '0' or '1'";
+    }
+}
+
+
+sub qr {
+    my ( $self, $string, $ecc, $version, $moduleSize ) = @_;
+    $ecc        ||= 'L';
+    $version    ||= 5;
+    $moduleSize ||= 3;
+
+    my %eccAllowedValues;
+    @eccAllowedValues{qw(L M Q H)} = ();
+    confess "Ecc must be one of 'L', 'M', 'Q' or 'H'"
+      unless ( exists $eccAllowedValues{$ecc} );
+    confess "Version must be between 1 to 40"
+      unless ( $version <= 40 and $version >= 1 and $version =~ /\d?\d/ );
+    confess "Module size must be between a positive integer"
+      unless ( isint $moduleSize == 1 );
+
+    my $qrImage =
+      GD::Barcode::QRcode->new( $string,
+        { Ecc => $ecc, Version => $version, ModuleSize => $moduleSize } )
+      ->plot();
+    $self->image($qrImage);
+}
+
+
+sub utf8ImagedText {
+    my ( $self, $string, %params ) = @_;
+    my $fontFamily = $params{fontFamily} // "Purisa";
+    my $fontStyle  = $params{fontStyle}  // "Normal";
+    my $fontSize   = $params{fontSize}   // 20;
+    my $lineHeight = $params{lineHeight} // 42;
+    my $paperWidth = $params{paperWidth} // 500;
+
+    my $surface =
+      Cairo::ImageSurface->create( 'argb32', $paperWidth, $lineHeight );
+    my $cr = Cairo::Context->create($surface);
+    $cr->set_antialias('none');
+    $cr->set_source_rgb( 255, 255, 255 );
+    $cr->paint();
+    $cr->set_source_rgb( 0, 0, 0 );
+    my $layout = Pango::Cairo::create_layout($cr);
+    $layout->set_text($string);
+    my $font =
+      Pango::FontDescription->from_string("$fontFamily $fontStyle $fontSize");
+    $layout->set_font_description($font);
+
+    Pango::Cairo::show_layout( $cr, $layout );
+    my $tempdir = File::Temp::tempdir();
+    $surface->write_to_png( $tempdir . '/cairopangoprinterimage.png' );
+    my $img = newFromPng GD::Image( $tempdir . '/cairopangoprinterimage.png' )
+      || die "Error $!";
+    $self->image($img);
+}
+
+
+sub image {
+    my ( $self, $img ) = @_;
+    my $paddingLeft  = '';
+    my $paddingRight = '';
+
+    if ( $img->width > 512 ) {
+        carp
+'Width is greater than 512 pixels and could be truncated at print time';
+    }
+    if ( $img->height > 255 ) {
+        confess 'Height is greater than 255 pixels';
+    }
+
+    my @padding = $self->_pad_image_size( $img->width );
+    for ( 1 .. $padding[0] ) {
+        $paddingLeft .= '0';
+    }
+    for ( 1 .. $padding[1] ) {
+        $paddingRight .= '0';
+    }
+
+    my $pixelLine = '';
+    my $switch    = 0;
+    my @imageSize = ( 0, 0 );
+    for my $y ( 0 .. $img->height - 1 ) {
+        $imageSize[1]++;
+        $pixelLine .= $paddingLeft;
+        $imageSize[0] += $padding[0];
+        for my $x ( 0 .. $img->width - 1 ) {
+            $imageSize[0]++;
+            my $index         = $img->getPixel( $x, $y );
+            my @rgb           = $img->rgb($index);
+            my $imageColour   = $rgb[0] + $rgb[1] + $rgb[2];
+            my $imagePattern  = "1X0";
+            my $patternLength = length $imagePattern;
+            $switch = ( $switch - 1 ) * (-1);
+            for my $x ( 1 .. $patternLength ) {
+
+                if ( $imageColour <= ( 255 * 3 / $patternLength * $x ) ) {
+                    my $patternAtX = substr( $imagePattern, $x - 1, 1 );
+                    if ( $patternAtX eq 'X' ) {
+                        $pixelLine .= $switch;
+                    }
+                    else {
+                        $pixelLine .= $patternAtX;
+                    }
+                    last;
+                }
+                elsif (
+                    $imageColour > ( 255 * 3 / $patternLength * $patternLength )
+                    and $imageColour <= ( 255 * 3 ) )
+                {
+                    $pixelLine .= substr( $imagePattern, -1, 1 );
+                    last;
+                }
+            }
+        }
+        $pixelLine .= $paddingRight;
+        $imageSize[0] += $padding[1];
+    }
+    $self->_print_image( $pixelLine, \@imageSize );
+}
+
+sub _pad_image_size {
+    my ( $self, $width ) = @_;
+
+    if ( $width % 32 == 0 ) {
+        return ( 0, 0 );
+    }
+    else {
+        my $border = 32 - ( $width % 32 );
+        if ( $border % 2 == 0 ) {
+            return ( $border / 2, $border / 2 );
+        }
+        else {
+            return ( $border / 2 - .5, $border / 2 + .5 );
+        }
+    }
+}
+
+sub _print_image {
+    my ( $self, $pixelLine, $imageSize ) = @_;
+
+    $self->driver->write( _GS . "v\x30\x00" );
+    my $buffer = sprintf(
+        "%02X%02X%02X%02X",
+        (
+            ( ( $imageSize->[0] / $imageSize->[1] ) / 8 ), 0, $imageSize->[1],
+            0
+        )
+    );
+    $self->driver->write( pack( "H*", $buffer ) );
+
+    $buffer = "";
+    my $i     = 0;
+    my $count = 0;
+    while ( $i < length($pixelLine) ) {
+        my $octalString = oct( "0b" . substr( $pixelLine, $i, 8 ) );
+        $buffer .= sprintf( "%02X", $octalString );
+        $i += 8;
+        $count++;
+        if ( $count % 4 == 0 ) {
+            $self->driver->write( pack( "H*", $buffer ) );
+            $buffer = "";
+            $count  = 0;
+        }
+    }
+}
+
+sub printAreaWidth {
+    my ( $self, $width ) = @_;
+
+    # Set a default width if no width is provided (standard 80mm)
+    $width //= 512;
+
+    # 1. Validation: Make sure it's defined and looks like a positive integer
+    unless ( defined $width && $width =~ /^\d+$/ && $width >= 1 && $width <= 65535 ) {
+        confess "Width must be a integer between 0 and 65535 in printAreaWidth(). Invalid value '" . ($width // '') . "'.
+        Usage: \n\t\$device->printer->printAreaWidth(\$width)\n";
+    }
+
+    # 2. Math: Break it into High and Low bytes (standard ESC/POS 16-bit)
+    my $nH = int( $width / 256 );
+    my $nL = $width % 256;
+
+    # 3. Write: Use our new standard driver 'write' method
+    $self->driver->write( "\x1D" . 'W' . chr($nL) . chr($nH) );
+}
+
+#sub printAreaWidth {
+#    my ( $self, $width ) = @_;
+#
+#    confess
+#"Width must be a integer between 0 and 65535 in printAreaWidth(). Invalid value '$width'.
+#        Usage: \n\t\$device->printer->printAreaWidth(\$width)\n"
+#      unless ( isint $width == 1 and $width <= 65535 and $width >= 1 );
+#
+#    my $nH = $width >> 8;
+#    my $nL = $width - ( $nH << 8 );
+#
+#    $self->driver->write( _GS . 'W' . chr($nL) . chr($nH) );
+#}
+
+
+sub tabPositions {
+    my ( $self, @positions ) = @_;
+    my $pos = '';
+
+    for (@positions) {
+        confess "Tab position must be a positive integer. Invalid value '$_'.
+        Usage: \n\t\$device->printer->tabPositions(4,8,16 ...)\n"
+          unless isint $_ == 1;
+    }
+
+    $pos .= chr($_) for @positions;
+    $self->driver->write( _ESC . 'D' . $pos . chr(0) );
+}
+
+
+sub tab {
+    my ($self) = @_;
+
+    $self->driver->write("\t");
+}
+
+
+sub lf {
+    my ($self) = @_;
+
+    $self->driver->write("\n");
+}
+
+
+sub ff {
+    my ($self) = @_;
+
+    $self->driver->write("\x0c");
+}
+
+
+sub cr {
+    my ($self) = @_;
+
+    $self->driver->write("\x0d");
+}
+
+
+sub cancel {
+    my ($self) = @_;
+
+    $self->driver->write("\x18");
+}
+
+
+sub font {
+    my ( $self, $font ) = @_;
+    $font ||= 'a';
+
+    my %fontMap = (
+        a => "\x00",
+        b => "\x01",
+        c => "\x02",
+    );
+
+    confess "Invalid value for font '$font'. Use 'a', 'b' or 'c'.
+        Usage: \n\t\$device->printer->font('a')\n"
+      unless exists $fontMap{$font};
+
+    $self->fontStyle($font);
+    if ( $self->usePrintMode && $font ne 'c' ) {
+        $self->_updatePrintMode;
+    }
+    else {
+        $self->driver->write( _ESC . 'M' . $fontMap{$font} );
+    }
+}
+
+
+sub bold {
+    my ( $self, $bold ) = @_;
+    $bold ||= 0;
+
+    confess "Invalid value for bold '$bold'. Use '0' or '1'.
+        Usage: \n\t\$device->printer->bold(1)\n"
+      unless ( $bold == 1 or $bold == 0 );
+
+    $self->emphasizedStatus($bold);
+    if ( $self->usePrintMode ) {
+        $self->_updatePrintMode;
+    }
+    else {
+        $self->driver->write( _ESC . 'E' . int($bold) );
+    }
+}
+
+
+sub doubleStrike {
+    my ( $self, $doubleStrike ) = @_;
+    $doubleStrike ||= 0;
+
+    confess "Invalid value for doubleStrike '$doubleStrike'. Use '0' or '1'.
+        Usage: \n\t\$device->printer->doubleStrike(1)\n"
+      unless ( $doubleStrike == 1 or $doubleStrike == 0 );
+
+    $self->driver->write( _ESC . 'G' . int($doubleStrike) );
+}
+
+
+sub underline {
+    my ( $self, $underline ) = @_;
+    $underline ||= 0;
+
+    confess "Invalid value for underline '$underline'. Use '0', '1' or '2'.
+        Usage: \n\t\$device->printer->underline(1)\n"
+      unless ( $underline == 2 or $underline == 1 or $underline == 0 );
+
+    $self->underlineStatus($underline);
+    if ( $self->usePrintMode ) {
+        $self->_updatePrintMode;
+    }
+    else {
+        $self->driver->write( _ESC . '-' . $underline );
+    }
+}
+
+
+sub invert {
+    my ( $self, $invert ) = @_;
+    $invert ||= 0;
+
+    confess "Invalid value for invert '$invert'. Use '0' or '1'.
+        Usage: \n\t\$device->printer->invert(1)\n"
+      unless ( $invert == 1 or $invert == 0 );
+
+    $self->driver->write( _GS . 'B' . chr($invert) );
+}
+
+
+sub color {
+    my ( $self, $color ) = @_;
+    $color ||= 0;
+
+    confess "Invalid value for color '$color'. Use '0' or a positive integer.
+        Usage: \n\t\$device->printer->color(1)\n" unless ( isint $color >= 0 );
+
+    $self->driver->write( _ESC . 'r' . chr($color) );
+}
+
+
+sub justify {
+    my ( $self, $justify ) = @_;
+    $justify ||= 'left';
+    my %jmap = (
+        left   => 0,
+        center => 1,
+        right  => 2,
+        full   => 3,
+    );
+
+    confess
+"Invalid value for justify '$justify'. Use 'full', 'left', 'center' or 'right'.
+        Usage: \n\t\$device->printer->justify('left')\n"
+      unless ( exists $jmap{$justify} );
+
+    $self->driver->write( _ESC . 'a' . int( $jmap{ lc $justify } ) );
+}
+
+
+sub upsideDown {
+    my ( $self, $upsideDown ) = @_;
+    $upsideDown ||= 0;
+
+    confess "Invalid value for upsideDown '$upsideDown'. Use '0' or '1'.
+        Usage: \n\t\$device->printer->upsideDown(1)\n"
+      unless ( $upsideDown == 1 or $upsideDown == 0 );
+
+    $self->lf();
+    $self->driver->write( _ESC . '{' . int($upsideDown) );
+}
+
+
+sub fontHeight {
+    my ( $self, $height ) = @_;
+    $height ||= 0;
+    my $width = $self->widthStatus;
+
+    confess
+"Invalid value for fontHeight '$height'. Use a integer between '0' and '7'.
+        Usage: \n\t\$device->printer->fontHeight(5)\n"
+      unless ( isint $height >= 0 and $height <= 7 );
+
+    $self->heightStatus($height);
+    if ( $self->usePrintMode ) {
+        $self->_updatePrintMode;
+    }
+    else {
+        $self->driver->write( _GS . '!' . chr( $width << 4 | $height ) );
+    }
+}
+
+
+sub fontWidth {
+    my ( $self, $width ) = @_;
+    $width ||= 0;
+    my $height = $self->heightStatus;
+
+    confess
+      "Invalid value for fontWidth '$width'. Use a integer between '0' and '7'.
+        Usage: \n\t\$device->printer->fontWidth(5)\n"
+      unless ( isint $width >= 0 and $width <= 7 );
+
+    $self->widthStatus($width);
+    if ( $self->usePrintMode ) {
+        $self->_updatePrintMode;
+    }
+    else {
+        $self->driver->write(
+            _GS . '!' . chr( int($width) << 4 | int($height) ) );
+    }
+}
+
+
+sub charSpacing {
+    my ( $self, $charSpacing ) = @_;
+    $charSpacing ||= 0;
+
+    confess
+"Invalid value for charSpacing '$charSpacing'. Use a integer between '0' and '255'.
+        Usage: \n\t\$device->printer->charSpacing(5)\n"
+      unless ( isint $charSpacing >= 0 and $charSpacing <= 255 );
+
+    $self->driver->write( _ESC . _SP . chr($charSpacing) );
+}
+
+
+sub lineSpacing {
+    my ( $self, $lineSpacing, $commandSet ) = @_;
+    $lineSpacing ||= 30;
+    $commandSet  ||= '3';
+
+    if ( $commandSet eq '+' or $commandSet eq '3' ) {
+        confess
+"Invalid value for lineSpacing '$lineSpacing'. Use a integer between '0' and '255' with this commandSet.
+            Usage: \n\t\$device->printer->lineSpacing(5, 'A')\n"
+          unless ( isint $lineSpacing >= 0 and $lineSpacing <= 255 );
+    }
+    elsif ( $commandSet eq 'A' ) {
+        confess
+"Invalid value for lineSpacing '$lineSpacing'. Use a integer between '0' and '85' with commandSet 'A'.
+            Usage: \n\t\$device->printer->lineSpacing(5, 'A')\n"
+          unless ( isint $lineSpacing >= 0 and $lineSpacing <= 85 );
+    }
+    else {
+        confess
+          "Invalid value for commandSet '$commandSet'. Use 'A', '3' or '+'.
+            Usage: \n\t\$device->printer->lineSpacing(5, 'A')\n";
+    }
+
+    $self->driver->write( _ESC . $commandSet . chr($lineSpacing) );
+}
+
+
+sub selectDefaultLineSpacing {
+    my ($self) = @_;
+    $self->driver->write( _ESC . '2' );
+}
+
+
+sub printPosition {
+    my ( $self, $length, $height ) = @_;
+
+    confess
+      "Invalid value for length '$length'. Use a integer between '0' and '255'.
+        Usage: \n\t\$device->printer->printPosition(5, 6)\n"
+      unless ( isint $length >= 0 and $length <= 255 );
+    confess
+      "Invalid value for length '$height'. Use a integer between '0' and '255'.
+        Usage: \n\t\$device->printer->printPosition(5, 6)\n"
+      unless ( isint $height >= 0 and $height <= 255 );
+
+    $self->driver->write( _ESC . '$' . chr($length) . chr($height) );
+}
+
+
+sub leftMargin {
+    my ( $self, $leftMargin ) = @_;
+
+    confess
+"Invalid value for leftMargin '$leftMargin'. Use a integer between '0' and '255'.
+        Usage: \n\t\$device->printer->leftMargin(30)\n"
+      unless ( isint $leftMargin >= 0 and $leftMargin <= 255 );
+
+    my $nH = $leftMargin >> 8;
+    my $nL = $leftMargin - ( $nH << 8 );
+
+    $self->driver->write( _GS . 'L' . chr($nL) . chr($nH) );
+}
+
+
+sub rot90 {
+    my ( $self, $rotate ) = @_;
+
+    confess "Invalid value for rot90 '$rotate'. Use '0' or '1'.
+        Usage: \n\t\$device->printer->rot90(1)\n"
+      unless ( $rotate == 1 or $rotate == 0 );
+
+    $self->driver->write( _ESC . 'V' . chr($rotate) );
+}
+
+# This is a redundant function in ESCPOS which updates the printer
+sub _updatePrintMode {
+    my ($self) = @_;
+    my %fontMap = (
+        a => 0,
+        b => 1,
+    );
+
+    my $value =
+        $fontMap{ $self->fontStyle } . '00'
+      . $self->emphasizedStatus
+      . ( $self->heightStatus ? '1' : '0' )
+      . ( $self->widthStatus  ? '1' : '0' ) . '0'
+      . $self->underlineStatus;
+    $self->driver->write( _ESC . '!' . pack( "b*", $value ) );
+}
+
+# BEGIN: BARCODE functions
+
+
+sub barcode {
+    my ( $self, %params ) = @_;
+
+    my %map = (
+        none          => 0,
+        above         => 1,
+        below         => 2,
+        aboveandbelow => 3,
+    );
+
+    $self->driver->write(
+        _GS . 'H' . chr( $map{ $params{HRIPosition} || 'below' } ) );
+
+    %map = (
+        a => 0,
+        b => 1,
+    );
+    $self->driver->write( _GS . 'f' . chr( $map{ $params{font} || 'b' } ) );
+
+    $self->driver->write( _GS . 'h' . chr( $params{height} || 50 ) );
+
+    $self->driver->write( _GS . 'w' . chr( $params{width} || 2 ) );
+
+    %map = (
+        'UPC-A' => 0,
+        'UPC-B' => 1,
+        JAN13   => 2,
+        JAN8    => 3,
+        CODE39  => 4,
+        ITF     => 5,
+        CODABAR => 6,
+        CODE93  => 7,
+        CODE128 => 8,
+    );
+    $params{system} ||= 'CODE93';
+
+    if ( exists $map{ $params{system} } ) {
+        $self->driver->write( _GS . 'k'
+              . chr( $map{ $params{system} } + 65 )
+              . chr( length $params{barcode} )
+              . $params{barcode} );
+    }
+    else {
+        confess "Invalid system in barcode";
+    }
+}
+
+# END: BARCODE functions
+
+# BEGIN: Bitmap printing methods
+
+
+sub printNVImage {
+    my ( $self, $flag ) = @_;
+
+    $self->driver->write( _FS . 'p' . chr(1) . chr($flag) );
+}
+
+
+sub printImage {
+    my ( $self, $flag ) = @_;
+
+    $self->driver->write( _GS . '/' . chr($flag) );
+}
+
+# END: Bitmap printing methods
+
+# BEGIN: Peripheral and cutter Control Commands
+
+
+sub cutPaper {
+    my ( $self, %params ) = @_;
+    $params{feed} ||= 0;
+
+    $self->lf();
+    if ( $params{feed} == 0 ) {
+        $self->driver->write( _GS . 'V' . chr(1) );
+    }
+    else {
+        $self->driver->write( _GS . 'V' . chr(66) . chr(0) );
+    }
+
+}
+
+
+sub drawerKickPulse {
+    my ( $self, $pin, $time ) = @_;
+    $pin  = defined $pin  ? $pin  : 0;
+    $time = defined $time ? $time : 8;
+
+    $self->driver->write( _DLE . _DC4 . "\x01" . chr($pin) . chr($time) );
+}
+
+# End Peripheral Control Commands
+
+# BEGIN: Printer STATUS methods
+
+
+sub printerStatus {
+    my ($self) = @_;
+
+    my @flags =
+      split( //,
+        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x01", 255 ) ) );
+    return {
+        drawer_pin3_high            => $flags[5],
+        offline                     => $flags[4],
+        waiting_for_online_recovery => $flags[2],
+        feed_button_pressed         => $flags[1],
+    };
+}
+
+
+sub offlineStatus {
+    my ($self) = @_;
+
+    my @flags =
+      split( //,
+        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x02", 255 ) ) );
+    return {
+        cover_is_closed     => $flags[5],
+        feed_button_pressed => $flags[4],
+        paper_end           => $flags[2],
+        error               => $flags[1],
+    };
+}
+
+
+sub errorStatus {
+    my ($self) = @_;
+
+    my @flags =
+      split( //,
+        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x03", 255 ) ) );
+    return {
+        auto_cutter_error     => $flags[4],
+        unrecoverable_error   => $flags[2],
+        autorecoverable_error => $flags[1],
+    };
+}
+
+
+sub paperSensorStatus {
+    my ($self) = @_;
+
+    my @flags =
+      split( //,
+        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x04", 255 ) ) );
+    return {
+        paper_roll_near_end_sensor_1 => $flags[5],
+        paper_roll_near_end_sensor_2 => $flags[4],
+        paper_roll_status_sensor_1   => $flags[2],
+        paper_roll_status_sensor_2   => $flags[1],
+    };
+}
+
+
+sub inkStatusA {
+    my ($self) = @_;
+
+    my @flags = split(
+        //,
+        unpack(
+            "B*", $self->driver->read( _DLE . _EOT . "\x07" . "\x01", 255 )
+        )
+    );
+    return {
+        ink_near_end          => $flags[5],
+        ink_end               => $flags[4],
+        ink_cartridge_missing => $flags[2],
+        cleaning_in_progress  => $flags[1],
+    };
+}
+
+
+sub inkStatusB {
+    my ($self) = @_;
+
+    my @flags = split(
+        //,
+        unpack(
+            "B*", $self->driver->read( _DLE . _EOT . "\x07" . "\x02", 255 )
+        )
+    );
+    return {
+        ink_near_end          => $flags[5],
+        ink_end               => $flags[4],
+        ink_cartridge_missing => $flags[2],
+    };
+}
+
+# END: Printer STATUS methods
+
+no Moo;
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Printer::ESCPOS::Profiles::Generic - Generic Profile for Printers for L<Printer::ESCPOS>. Most common functions are included here.
+
+=head1 VERSION
+
+version 1.006
+
+=head1 METHODS
+
+=head2 init
+
+Initializes the Printer. Clears the data in print buffer and resets the printer to the mode that was in effect when the
+power was turned on. This function is automatically called on creation of printer object.
+
+=head2 enable
 
 Enables/Disables the printer with a '_ESC =' command (Set peripheral device). When disabled, the printer ignores all
 commands except enable() or other real-time commands.
@@ -55,21 +812,7 @@ Pass B<1> to enable, pass B<0> to disable
     $device->printer->enable(0) # disabled
     $device->printer->enable(1) # enabled
 
-=cut
-
-sub enable {
-    my ( $self, $n ) = @_;
-
-    if ( $n == 1 ) {
-        $self->driver->print( _ESC . '=' . chr(1) );
-    } elsif( $n == 0 ){
-        $self->driver->print( _ESC . '=' . chr(2) );
-    } else {
-        confess "Invalid parameter please use '0' or '1'";
-    }
-}
-
-=method qr
+=head2 qr
 
 Prints a qr code to the printer. In Generic profile, this creates a QR Code image using L<GD::Barcode::QRcode>. A native
 implementation may be created using a printer model specific profile.
@@ -121,25 +864,7 @@ I<moduleSize> (optional, default B<3>): width of each module in pixels.
 
 You may also call align() before calling qr() to set alignment on the page.
 
-=cut
-
-sub qr {
-    my ($self, $string, $ecc, $version, $moduleSize) = @_;
-    $ecc ||= 'L';
-    $version ||= 5;
-    $moduleSize ||= 3;
-
-    my %eccAllowedValues;
-    @eccAllowedValues{qw(L M Q H)} = ();
-    confess "Ecc must be one of 'L', 'M', 'Q' or 'H'" unless(exists $eccAllowedValues{$ecc});
-    confess "Version must be between 1 to 40" unless($version <= 40 and $version >= 1 and $version =~ /\d?\d/);
-    confess "Module size must be between a positive integer" unless(isint $moduleSize == 1);
-
-    my $qrImage = GD::Barcode::QRcode->new($string,{ Ecc => $ecc, Version => $version, ModuleSize => $moduleSize})->plot();
-    $self->image($qrImage);
-}
-
-=method utf8ImagedText
+=head2 utf8ImagedText
 
     use utf8;
 
@@ -176,36 +901,7 @@ I<lineHeight> (optional, default B<42>): Line Height in pixels, make sure this i
 I<paperWidth> (optional, default B<500>): This is set to 500 pixels by default as this is the most common width for receipt printers. Change this
 as per your printer specs.
 
-=cut
-
-sub utf8ImagedText {
-    my ($self, $string, %params) = @_;
-    my $fontFamily = $params{fontFamily} // "Purisa";
-    my $fontStyle = $params{fontStyle} // "Normal";
-    my $fontSize = $params{fontSize} // 20;
-    my $lineHeight = $params{lineHeight} // 42;
-    my $paperWidth = $params{paperWidth} // 500;
-
-
-    my $surface = Cairo::ImageSurface->create('argb32', $paperWidth, $lineHeight);
-    my $cr = Cairo::Context->create ($surface);
-    $cr->set_antialias('none');
-    $cr->set_source_rgb (255, 255, 255);
-    $cr->paint();
-    $cr->set_source_rgb (0, 0, 0);
-    my $layout = Pango::Cairo::create_layout ($cr);
-    $layout->set_text ($string);
-    my $font = Pango::FontDescription->from_string ("$fontFamily $fontStyle $fontSize");
-    $layout->set_font_description ($font);
-
-    Pango::Cairo::show_layout($cr, $layout);
-    my $tempdir = File::Temp::tempdir();
-    $surface->write_to_png ($tempdir . '/cairopangoprinterimage.png');
-    my $img = newFromPng GD::Image($tempdir . '/cairopangoprinterimage.png') || die "Error $!";
-    $self->image($img);
-}
-
-=method image
+=head2 image
 
 Prints a image to the printer. Takes a L<GD> Image object as input. <Maximum printable image dimensions are 512x255
 
@@ -218,105 +914,7 @@ I<image>: L<GD> image object for the image to be printed.
 
 You may also call align() before calling qr() to set alignment on the page.
 
-=cut
-
-sub image {
-    my ($self, $img) = @_;
-    my $paddingLeft = '';
-    my $paddingRight = '';
-
-    if($img->width > 512) {
-        carp 'Width is greater than 512 pixels and could be truncated at print time';
-    }
-    if($img->height > 255) {
-        confess 'Height is greater than 255 pixels';
-    }
-
-    my @padding = $self->_pad_image_size( $img->width );
-    for (1 .. $padding[0]) {
-        $paddingLeft .= '0';
-    }
-    for (1 .. $padding[1]) {
-        $paddingRight .= '0';
-    }
-
-    my $pixelLine = '';
-    my $switch = 0;
-    my @imageSize = (0,0);
-    for my $y(0 .. $img->height - 1) {
-        $imageSize[1]++;
-        $pixelLine .= $paddingLeft;
-        $imageSize[0] += $padding[0];
-        for my $x(0 .. $img->width - 1) {
-            $imageSize[0]++;
-            my $index = $img->getPixel($x, $y);
-            my @rgb = $img->rgb($index);
-            my $imageColour = $rgb[0] + $rgb[1] + $rgb[2];
-            my $imagePattern = "1X0";
-            my $patternLength = length $imagePattern;
-            $switch = ($switch - 1) * (-1);
-            for my $x(1 .. $patternLength) {
-                if($imageColour <= (255 * 3 / $patternLength * $x)) {
-                    my $patternAtX = substr($imagePattern, $x - 1, 1);
-                    if($patternAtX eq 'X') {
-                        $pixelLine .= $switch;
-                    } else {
-                        $pixelLine .= $patternAtX;
-                    }
-                    last;
-                } elsif($imageColour > (255 * 3 / $patternLength * $patternLength) and $imageColour <= (255 * 3)) {
-                    $pixelLine .= substr($imagePattern, -1, 1);
-                    last;
-                }
-            }
-      }
-      $pixelLine .= $paddingRight;
-      $imageSize[0] += $padding[1];
-    }
-    $self->_print_image($pixelLine, \@imageSize);
-}
-
-
-sub _pad_image_size {
-    my($self, $width) = @_;
-
-    if($width % 32 == 0) {
-        return (0,0);
-    } else {
-        my $border = 32 - ($width % 32);
-        if( $border % 2 == 0 ) {
-            return ($border/2, $border/2);
-        } else {
-            return ($border/2 - .5, $border/2 + .5);
-        }
-    }
-}
-
-
-sub _print_image {
-    my ($self, $pixelLine, $imageSize) = @_;
-
-    $self->driver->write(_GS . "v\x30\x00");
-    my $buffer = sprintf("%02X%02X%02X%02X", ((($imageSize->[0] / $imageSize->[1]) / 8), 0, $imageSize->[1], 0));
-    $self->driver->write(pack("H*", $buffer));
-
-    $buffer = "";
-    my $i = 0;
-    my $count = 0;
-    while($i < length($pixelLine)) {
-        my $octalString = oct("0b" . substr($pixelLine, $i, 8));
-        $buffer .= sprintf("%02X", $octalString);
-        $i += 8;
-        $count++;
-        if($count % 4 == 0) {
-            $self->driver->write(pack("H*", $buffer));
-            $buffer = "";
-            $count = 0;
-        }
-    }
-}
-
-=method printAreaWidth
+=head2 printAreaWidth
 
 Sets the Print area width specified by width.
 
@@ -332,22 +930,7 @@ off.
 Note: If you are using Printer::ESCPOS version prior to v1.* Please check documentation for older version of this module
 the nL and nH syntax for this method.
 
-=cut
-
-sub printAreaWidth {
-    my ( $self, $width ) = @_;
-
-    confess "Width must be a integer between 0 and 65535 in printAreaWidth(). Invalid value '$width'.
-        Usage: \n\t\$device->printer->printAreaWidth(\$width)\n"
-        unless(isint $width == 1 and $width <=65535 and $width >= 1);
-
-    my $nH = $width >> 8;
-    my $nL = $width - ($nH << 8);
-
-    $self->driver->write( _GS . 'W' . chr( $nL ) . chr( $nH ) );
-}
-
-=method tabPositions
+=head2 tabPositions
 
 Sets horizontal tab positions for tab stops. Upto 32 tab positions can be set in most receipt printers.
 
@@ -369,24 +952,9 @@ This would print a well aligned receipt like so:
     2  x Pizza                     $500.50
     1  x Tandoori Chicken          $50.20
 
-
 Common tab positions are usually in intervals of 8 chars (9, 17, 25) etc.
 
-=cut
-
-sub tabPositions {
-    my ( $self, @positions ) = @_;
-    my $pos = '';
-
-    for (@positions) {confess "Tab position must be a positive integer. Invalid value '$_'.
-        Usage: \n\t\$device->printer->tabPositions(4,8,16 ...)\n"
-        unless isint $_ == 1};
-
-    $pos .= chr( $_ ) for @positions;
-    $self->driver->write( _ESC . 'D' . $pos . chr(0) );
-}
-
-=method tab
+=head2 tab
 
 moves the cursor to next horizontal tab position like a "\t". This command is ignored unless the next horizontal tab
 position has been set. You may substitute this command with a "\t" as well.
@@ -401,15 +969,7 @@ is same as this
 
     $device->printer->text("blah blah\tblah2 blah2");
 
-=cut
-
-sub tab {
-    my ( $self ) = @_;
-
-    $self->driver->write( "\t" );
-}
-
-=method lf
+=head2 lf
 
 line feed. Moves to the next line. You can substitute this method with {"\n"} in your print or write method e.g. :
 
@@ -423,53 +983,21 @@ is same as this
 
     $device->printer->text("blah blah\nblah2 blah2");
 
-=cut
-
-sub lf {
-    my ( $self ) = @_;
-
-    $self->driver->write( "\n" );
-}
-
-=method ff
+=head2 ff
 
 When in page mode, print data in the buffer and return back to standard mode
 
-=cut
-
-sub ff {
-    my ( $self ) = @_;
-
-    $self->driver->write( "\x0c" );
-}
-
-=method cr
+=head2 cr
 
 Print and carriage return
 
 When automatic line feed is enabled this method works the same as lf , else it is ignored.
 
-=cut
-
-sub cr {
-    my ( $self ) = @_;
-
-    $self->driver->write( "\x0d" );
-}
-
-=method cancel
+=head2 cancel
 
 Cancel (delete) page data in page mode
 
-=cut
-
-sub cancel {
-    my ( $self ) = @_;
-
-    $self->driver->write( "\x18" );
-}
-
-=method font
+=head2 font
 
 Set Font style, you can pass *a*, *b* or *c*. Many printers don't support style *c* and only have two supported styles.
 
@@ -480,30 +1008,7 @@ I<font> (optional, default 'a'): Font to set for the printer
     $device->printer->font('b');
     $device->printer->text('Writing in Font B');
 
-=cut
-
-sub font {
-    my ( $self, $font ) = @_;
-    $font ||= 'a';
-
-    my %fontMap = (
-        a => "\x00",
-        b => "\x01",
-        c => "\x02",
-    );
-
-    confess "Invalid value for font '$font'. Use 'a', 'b' or 'c'.
-        Usage: \n\t\$device->printer->font('a')\n" unless exists $fontMap{$font};
-
-    $self->fontStyle( $font );
-    if( $self->usePrintMode && $font ne 'c') {
-        $self->_updatePrintMode;
-    } else {
-        $self->driver->write( _ESC . 'M' . $fontMap{$font});
-    }
-}
-
-=method bold
+=head2 bold
 
 Set bold mode *0* for off and *1* for on. Also called emphasized mode in some printer manuals
 
@@ -514,24 +1019,7 @@ I<bold> (optional, default 0): 1 or 0 to set or unset bold.
     $device->printer->bold(0);
     $device->printer->text("This is not Bold Text\n");
 
-=cut
-
-sub bold {
-    my ( $self, $bold ) = @_;
-    $bold ||= 0;
-
-    confess "Invalid value for bold '$bold'. Use '0' or '1'.
-        Usage: \n\t\$device->printer->bold(1)\n" unless($bold == 1 or $bold == 0);
-
-    $self->emphasizedStatus( $bold );
-    if( $self->usePrintMode ) {
-        $self->_updatePrintMode;
-    } else {
-        $self->driver->write( _ESC . 'E' . int( $bold ) );
-    }
-}
-
-=method doubleStrike
+=head2 doubleStrike
 
 Set double-strike mode *0* for off and *1* for on
 
@@ -542,19 +1030,7 @@ I<doubleStrike> (optional, default 0): 1 or 0 to doubleStrike or unset doubleStr
     $device->printer->doubleStrike(0);
     $device->printer->text("This is not Double Striked  Text\n");
 
-=cut
-
-sub doubleStrike {
-    my ( $self, $doubleStrike ) = @_;
-    $doubleStrike ||= 0;
-
-    confess "Invalid value for doubleStrike '$doubleStrike'. Use '0' or '1'.
-        Usage: \n\t\$device->printer->doubleStrike(1)\n" unless($doubleStrike == 1 or $doubleStrike == 0);
-
-    $self->driver->write( _ESC . 'G' . int( $doubleStrike ) );
-}
-
-=method underline
+=head2 underline
 
 Set underline, *0* for off, *1* for on and *2* for double thickness
 
@@ -567,24 +1043,7 @@ I<underline> (optional, default 0): 1 or 0 to underline or unset underline.
     $device->printer->underline(0);
     $device->printer->text("This is not Underlined Text\n");
 
-=cut
-
-sub underline {
-    my ( $self, $underline ) = @_;
-    $underline ||= 0;
-
-    confess "Invalid value for underline '$underline'. Use '0', '1' or '2'.
-        Usage: \n\t\$device->printer->underline(1)\n" unless($underline == 2 or $underline == 1 or $underline == 0);
-
-    $self->underlineStatus($underline);
-    if( $self->usePrintMode ) {
-        $self->_updatePrintMode;
-    } else {
-        $self->driver->write( _ESC . '-' . $underline );
-    }
-}
-
-=method invert
+=head2 invert
 
 Reverse white/black printing mode pass *0* for off and *1* for on
 
@@ -595,19 +1054,7 @@ I<invert> (optional, default 0): 1 or 0 to invert or unset invert.
     $device->printer->invert(0);
     $device->printer->text("This is not Inverted Text\n");
 
-=cut
-
-sub invert {
-    my ( $self, $invert ) = @_;
-    $invert ||= 0;
-
-    confess "Invalid value for invert '$invert'. Use '0' or '1'.
-        Usage: \n\t\$device->printer->invert(1)\n" unless($invert == 1 or $invert == 0);
-
-    $self->driver->write( _GS . 'B' . chr( $invert ) );
-}
-
-=method color
+=head2 color
 
 Most thermal printers support just one color, black. Some ESCPOS printers(especially dot matrix) also support a second
 color, usually red. A few rarer models also support upto 7 different colors. In many models, this only works when the
@@ -624,20 +1071,7 @@ I<color> (optional, default 0): color number 0, 1 ...
     $device->printer->text("Red");
     $device->printer->print();
 
-
-=cut
-
-sub color {
-    my ( $self, $color ) = @_;
-    $color ||= 0;
-
-    confess "Invalid value for color '$color'. Use '0' or a positive integer.
-        Usage: \n\t\$device->printer->color(1)\n" unless(isint $color >= 0);
-
-    $self->driver->write( _ESC . 'r' . chr( $color ) );
-}
-
-=method justify
+=head2 justify
 
 Set Justification. Options B<full>, B<left>, B<right> and B<center>
 
@@ -646,47 +1080,16 @@ I<justify> (optional, default 'left'): B<full>, B<left>, B<right> or B<center>
     $device->printer->justify( 'right' );
     $device->printer->text("This is right justified");
 
-=cut
-
-sub justify {
-    my ( $self, $justify ) = @_;
-    $justify ||= 'left';
-    my %jmap = (
-        left   => 0,
-        center => 1,
-        right  => 2,
-        full   => 3,
-    );
-
-    confess "Invalid value for justify '$justify'. Use 'full', 'left', 'center' or 'right'.
-        Usage: \n\t\$device->printer->justify('left')\n" unless(exists $jmap{$justify});
-
-    $self->driver->write( _ESC . 'a' . int( $jmap{lc $justify} ) );
-}
-
-=method upsideDown
+=head2 upsideDown
 
 Sets Upside Down Printing on/off (pass *0* or *1*)
 
 I<upsideDown> (optional, default 0): B<0> or B<1>
 
-    $device->printer->upsideDown(1);
+    $device->printer->upsideDownPrinting(1);
     $device->printer->text("This text is upside down");
 
-=cut
-
-sub upsideDown {
-    my ( $self, $upsideDown ) = @_;
-    $upsideDown ||= 0;
-
-    confess "Invalid value for upsideDown '$upsideDown'. Use '0' or '1'.
-        Usage: \n\t\$device->printer->upsideDown(1)\n" unless($upsideDown == 1 or $upsideDown == 0);
-
-    $self->lf();
-    $self->driver->write( _ESC . '{' . int( $upsideDown ) );
-}
-
-=method fontHeight
+=head2 fontHeight
 
 Set font height. Only supports *0* or *1* for printmode set to 1, supports values *0*, *1*, *2*, *3*, *4*, *5*, *6* and
 *7* for non-printmode state (default)
@@ -701,25 +1104,7 @@ I<height> (optional, default 0): B<0> to B<7>
     $device->printer->text("quadruple height\n");
     . . .
 
-=cut
-
-sub fontHeight {
-    my ( $self, $height ) = @_;
-    $height ||= 0;
-    my $width = $self->widthStatus;
-
-    confess "Invalid value for fontHeight '$height'. Use a integer between '0' and '7'.
-        Usage: \n\t\$device->printer->fontHeight(5)\n" unless( isint $height >= 0 and $height <= 7);
-
-    $self->heightStatus( $height );
-    if( $self->usePrintMode ) {
-        $self->_updatePrintMode;
-    } else {
-        $self->driver->write( _GS . '!' . chr( $width << 4 | $height ));
-    }
-}
-
-=method fontWidth
+=head2 fontWidth
 
 Set font width. Only supports *0* or *1* for printmode set to 1, supports values *0*, *1*, *2*, *3*, *4*, *5*, *6* and
 *7* for non-printmode state (default)
@@ -734,25 +1119,7 @@ I<width> (optional, default 0): B<0> to B<7>
     $device->printer->text("quadruple width\n");
     . . .
 
-=cut
-
-sub fontWidth {
-    my ( $self, $width ) = @_;
-    $width ||= 0;
-    my $height = $self->heightStatus;
-
-    confess "Invalid value for fontWidth '$width'. Use a integer between '0' and '7'.
-        Usage: \n\t\$device->printer->fontWidth(5)\n" unless(isint $width >= 0 and $width <= 7);
-
-    $self->widthStatus( $width );
-    if( $self->usePrintMode ) {
-        $self->_updatePrintMode;
-    } else {
-        $self->driver->write( _GS . '!' . chr( int( $width ) << 4 | int( $height ) ));
-    }
-}
-
-=method charSpacing
+=head2 charSpacing
 
 Sets character spacing takes a value between 0 and 255
 
@@ -762,19 +1129,7 @@ I<charSpacing> (optional, default 0): B<0> to B<255>
     $device->printer->text("Blah Blah Blah\n");
     $device->printer->print();
 
-=cut
-
-sub charSpacing {
-    my ( $self, $charSpacing ) = @_;
-    $charSpacing ||= 0;
-
-    confess "Invalid value for charSpacing '$charSpacing'. Use a integer between '0' and '255'.
-        Usage: \n\t\$device->printer->charSpacing(5)\n" unless(isint $charSpacing >= 0 and $charSpacing <= 255);
-
-    $self->driver->write( _ESC . _SP . chr( $charSpacing ) );
-}
-
-=method lineSpacing
+=head2 lineSpacing
 
 Sets line spacing i.e the spacing between each line of printout. Note that some printers may not support all
 command sets for setting a line spacing. The most commonly available I<commandSet>('3') is used by default.
@@ -789,41 +1144,13 @@ I<commandSet>: ESCPOS provides three alternate commands for setting line spacing
     $device->printer->lineSpacing($lineSpacing); # Use default commandSet '3'
     $device->printer->lineSpacing($lineSpacing, $commandSet);
 
-=cut
-
-sub lineSpacing {
-    my ( $self, $lineSpacing, $commandSet ) = @_;
-    $lineSpacing ||= 30;
-    $commandSet  ||= '3';
-
-    if($commandSet eq '+' or $commandSet eq '3') {
-        confess "Invalid value for lineSpacing '$lineSpacing'. Use a integer between '0' and '255' with this commandSet.
-            Usage: \n\t\$device->printer->lineSpacing(5, 'A')\n" unless(isint $lineSpacing >= 0 and $lineSpacing <= 255);
-    } elsif($commandSet eq 'A') {
-        confess "Invalid value for lineSpacing '$lineSpacing'. Use a integer between '0' and '85' with commandSet 'A'.
-            Usage: \n\t\$device->printer->lineSpacing(5, 'A')\n" unless(isint $lineSpacing >= 0 and $lineSpacing <= 85);
-    } else {
-        confess "Invalid value for commandSet '$commandSet'. Use 'A', '3' or '+'.
-            Usage: \n\t\$device->printer->lineSpacing(5, 'A')\n";
-    }
-
-    $self->driver->write( _ESC . $commandSet . chr( $lineSpacing ) );
-}
-
-=method selectDefaultLineSpacing
+=head2 selectDefaultLineSpacing
 
 Reverts to default line spacing for the printer
 
     $device->printer->selectDefaultLineSpacing();
 
-=cut
-
-sub selectDefaultLineSpacing {
-    my ( $self ) = @_;
-    $self->driver->write( _ESC . '2' );
-}
-
-=method printPosition
+=head2 printPosition
 
 Sets the distance from the beginning of the line to the position at which characters are to be printed.
 
@@ -836,20 +1163,7 @@ I<height>: ranges from 0 to 255
 * 0 <= $length <= 255
 * 0 <= $height <= 255
 
-=cut
-
-sub printPosition {
-    my ( $self, $length, $height ) = @_;
-
-    confess "Invalid value for length '$length'. Use a integer between '0' and '255'.
-        Usage: \n\t\$device->printer->printPosition(5, 6)\n" unless(isint $length >= 0 and $length <= 255);
-    confess "Invalid value for length '$height'. Use a integer between '0' and '255'.
-        Usage: \n\t\$device->printer->printPosition(5, 6)\n" unless(isint $height >= 0 and $height <= 255);
-
-    $self->driver->write( _ESC . '$' . chr( $length )  . chr( $height ) );
-}
-
-=method leftMargin
+=head2 leftMargin
 
 Sets the left margin for printing. Set the left margin at the beginning of a line. The printer ignores any data
 preceding this command on the same line in the buffer.
@@ -861,25 +1175,10 @@ automatically set to the maximum value of the printable area.
 
     $device->printer->leftMargin($leftMargin);
 
-
 Note: If you are using Printer::ESCPOS version prior to v1.* Please check documentation for older version of this module
 the nL and nH syntax for this method.
 
-=cut
-
-sub leftMargin {
-    my ( $self, $leftMargin ) = @_;
-
-    confess "Invalid value for leftMargin '$leftMargin'. Use a integer between '0' and '255'.
-        Usage: \n\t\$device->printer->leftMargin(30)\n" unless(isint $leftMargin >= 0 and $leftMargin <= 255);
-
-    my $nH = $leftMargin >> 8;
-    my $nL = $leftMargin - ($nH << 8);
-
-    $self->driver->write( _GS . 'L' . chr( $nL ) . chr( $nH ) );
-}
-
-=method rot90
+=head2 rot90
 
 Rotate printout by 90 degrees
 
@@ -890,38 +1189,7 @@ I<rotate> (optional, default 0): B<0> or B<1>
     $device->printer->rot90(0);
     $device->printer->text("This is not rotated 90 degrees\n");
 
-=cut
-
-sub rot90 {
-    my ( $self, $rotate ) = @_;
-
-    confess "Invalid value for rot90 '$rotate'. Use '0' or '1'.
-        Usage: \n\t\$device->printer->rot90(1)\n" unless($rotate == 1 or $rotate == 0);
-
-    $self->driver->write( _ESC . 'V' . chr( $rotate ) );
-}
-
-# This is a redundant function in ESCPOS which updates the printer
-sub _updatePrintMode {
-    my ( $self ) = @_;
-    my %fontMap = (
-        a => 0,
-        b => 1,
-    );
-
-    my $value = $fontMap{ $self->fontStyle }
-    . '00'
-    . $self->emphasizedStatus
-    . ( $self->heightStatus?'1':'0' )
-    . ( $self->widthStatus?'1':'0' )
-    . '0'
-    . $self->underlineStatus;
-    $self->driver->write( _ESC . '!' . pack( "b*", $value ) );
-}
-
-# BEGIN: BARCODE functions
-
-=method barcode
+=head2 barcode
 
 This method prints a barcode to the printer. This can be bundled with other text formatting commands at the appropriate
 point where you would like to print a barcode on your print out. takes argument ~barcode~ as the barcode value.
@@ -973,69 +1241,7 @@ B<CODE128>
 
 I<barcode>: String to print as barcode.
 
-=cut
-
-sub barcode {
-    my ( $self, %params ) = @_;
-
-    my %map = (
-        none          => 0,
-        above         => 1,
-        below         => 2,
-        aboveandbelow => 3,
-    );
-
-    $self->driver->write( _GS . 'H' . chr(
-            $map{$params{HRIPosition} || 'below'}
-        ) );
-
-    %map = (
-        a => 0,
-        b => 1,
-    );
-    $self->driver->write( _GS . 'f' . chr(
-            $map{$params{font} || 'b'}
-        ) );
-
-    $self->driver->write( _GS . 'h' . chr(
-            $params{height} || 50
-        ) );
-
-    $self->driver->write( _GS . 'w' . chr(
-            $params{width} || 2
-        ) );
-
-    %map = (
-        'UPC-A' => 0,
-        'UPC-B' => 1,
-        JAN13   => 2,
-        JAN8    => 3,
-        CODE39  => 4,
-        ITF     => 5,
-        CODABAR => 6,
-        CODE93  => 7,
-        CODE128 => 8,
-    );
-    $params{system} ||= 'CODE93';
-
-    if(
-        exists $map{$params{system}}
-    ) {
-        $self->driver->write( _GS . 'k'
-            . chr( $map{$params{system}} + 65 )
-            . chr( length $params{barcode} )
-            . $params{barcode}
-        );
-    } else {
-        confess "Invalid system in barcode";
-    }
-}
-
-# END: BARCODE functions
-
-# BEGIN: Bitmap printing methods
-
-=method printNVImage
+=head2 printNVImage
 
 Prints bit image stored in Non-Volatile (NV) memory of the printer.
 
@@ -1048,15 +1254,7 @@ I<flag>: height and width
 * $flag = 2 # Normal width and Double Height
 * $flag = 3 # Double width and Double Height
 
-=cut
-
-sub printNVImage {
-    my ( $self, $flag ) = @_;
-
-    $self->driver->write( _FS . 'p' . chr(1) . chr($flag) );
-}
-
-=method printImage
+=head2 printImage
 
 Prints bit image stored in Volatile memory of the printer. This image gets erased when printer is reset.
 
@@ -1067,19 +1265,7 @@ Prints bit image stored in Volatile memory of the printer. This image gets erase
 * $flag = 2 # Normal width and Double Height
 * $flag = 3 # Double width and Double Height
 
-=cut
-
-sub printImage {
-    my ( $self, $flag ) = @_;
-
-    $self->driver->write( _GS . '/' . chr($flag) );
-}
-
-# END: Bitmap printing methods
-
-# BEGIN: Peripheral and cutter Control Commands
-
-=method cutPaper
+=head2 cutPaper
 
 Cuts the paper,
 
@@ -1093,22 +1279,7 @@ While not strictly a text formatting option, in receipt printer the cut paper in
 the text and text formatting data and the printer cuts the paper at the appropriate points wherever this command is
 used.
 
-=cut
-
-sub cutPaper {
-    my ( $self, %params ) = @_;
-    $params{feed} ||= 0;
-
-    $self->lf();
-    if( $params{feed} == 0 ) {
-        $self->driver->write( _GS . 'V' . chr(1));
-    } else {
-        $self->driver->write( _GS . 'V' . chr(66) . chr(0) );
-    }
-
-}
-
-=method drawerKickPulse
+=head2 drawerKickPulse
 
 Trigger drawer kick. Used to open cash drawer connected to the printer. In some use cases it may be used to trigger
 other devices by close contact.
@@ -1128,21 +1299,7 @@ of the text and text formatting data and the printer sends the pulse at the appr
 used. While originally designed for triggering a cash drawer to open, in practice this port can be used for all sorts of
 devices like pulsing light, or sound alarm etc.
 
-=cut
-
-sub drawerKickPulse {
-    my ( $self, $pin, $time ) = @_;
-    $pin  = defined $pin ? $pin : 0;
-    $time = defined $time ? $time : 8;
-
-    $self->driver->write( _DLE . _DC4 . "\x01" . chr( $pin )  . chr( $time ) );
-}
-
-# End Peripheral Control Commands
-
-# BEGIN: Printer STATUS methods
-
-=method printerStatus
+=head2 printerStatus
 
 Returns printer status in a hashref.
 
@@ -1153,24 +1310,7 @@ Returns printer status in a hashref.
         feed_button_pressed         => $flags[1],
     };
 
-=cut
-
-sub printerStatus {
-    my ( $self ) = @_;
-
-    my @flags = split(
-        //,
-        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x01", 255 ) )
-    );
-    return {
-        drawer_pin3_high            => $flags[5],
-        offline                     => $flags[4],
-        waiting_for_online_recovery => $flags[2],
-        feed_button_pressed         => $flags[1],
-    };
-}
-
-=method offlineStatus
+=head2 offlineStatus
 
 Returns a hashref for paper cover closed status, feed button pressed status, paper end stop status, and a aggregate
 error status either of which will prevent the printer from processing a printing request.
@@ -1182,24 +1322,7 @@ error status either of which will prevent the printer from processing a printing
         error               => $flags[1],
     };
 
-=cut
-
-sub offlineStatus {
-    my ( $self ) = @_;
-
-    my @flags = split(
-        //,
-        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x02", 255 ) )
-    );
-    return {
-        cover_is_closed     => $flags[5],
-        feed_button_pressed => $flags[4],
-        paper_end           => $flags[2],
-        error               => $flags[1],
-    };
-}
-
-=method errorStatus
+=head2 errorStatus
 
 Returns hashref with error flags for auto_cutter_error, unrecoverable error and auto-recoverable error
 
@@ -1209,23 +1332,7 @@ Returns hashref with error flags for auto_cutter_error, unrecoverable error and 
         autorecoverable_error => $flags[1],
     };
 
-=cut
-
-sub errorStatus {
-    my ( $self ) = @_;
-
-    my @flags = split(
-        //,
-        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x03", 255 ) )
-    );
-    return {
-        auto_cutter_error     => $flags[4],
-        unrecoverable_error   => $flags[2],
-        autorecoverable_error => $flags[1],
-    };
-}
-
-=method paperSensorStatus
+=head2 paperSensorStatus
 
 Gets printer paper Sensor status. Returns a hashref with four sensor statuses. Two paper near end sensors and two paper
 end sensors for printers supporting this feature. The exact returned status might differ based on the make of your
@@ -1238,24 +1345,7 @@ printer. If any of the flags is set to 1 it implies that the paper is out or nea
         paper_roll_status_sensor_2 => $flags[1],
     };
 
-=cut
-
-sub paperSensorStatus {
-    my ( $self ) = @_;
-
-    my @flags = split(
-        //,
-        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x04", 255 ) )
-    );
-    return {
-        paper_roll_near_end_sensor_1 => $flags[5],
-        paper_roll_near_end_sensor_2 => $flags[4],
-        paper_roll_status_sensor_1 => $flags[2],
-        paper_roll_status_sensor_2 => $flags[1],
-    };
-}
-
-=method inkStatusA
+=head2 inkStatusA
 
 Only available for dot-matrix and other ink consuming printers. Gets printer ink status for inkA(usually black ink).
 Returns a hashref with ink statuses.
@@ -1267,24 +1357,7 @@ Returns a hashref with ink statuses.
         cleaning_in_progress  => $flags[1],
     };
 
-=cut
-
-sub inkStatusA {
-    my ( $self ) = @_;
-
-    my @flags = split(
-        //,
-        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x07" . "\x01", 255 ) )
-    );
-    return {
-        ink_near_end          => $flags[5],
-        ink_end               => $flags[4],
-        ink_cartridge_missing => $flags[2],
-        cleaning_in_progress  => $flags[1],
-    };
-}
-
-=method inkStatusB
+=head2 inkStatusB
 
 Only available for dot-matrix and other ink consuming printers. Gets printer ink status for inkB(usually red ink).
 Returns a hashref with ink statuses.
@@ -1295,25 +1368,15 @@ Returns a hashref with ink statuses.
         ink_cartridge_missing => $flags[2],
     };
 
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
 =cut
-
-sub inkStatusB {
-    my ( $self ) = @_;
-
-    my @flags = split(
-        //,
-        unpack( "B*", $self->driver->read( _DLE . _EOT . "\x07" . "\x02", 255 ) )
-    );
-    return {
-        ink_near_end          => $flags[5],
-        ink_end               => $flags[4],
-        ink_cartridge_missing => $flags[2],
-    };
-}
-
-# END: Printer STATUS methods
-
-no Moo;
-__PACKAGE__->meta->make_immutable;
-
-1;

--- a/lib/Printer/ESCPOS/Profiles/SinocanPSeries.pm
+++ b/lib/Printer/ESCPOS/Profiles/SinocanPSeries.pm
@@ -5,8 +5,15 @@ package Printer::ESCPOS::Profiles::SinocanPSeries;
 
 # PODNAME: Printer::ESCPOS::Profiles::SinocanPSeries
 # ABSTRACT: Sinocan P Series Profile for Printers for L<Printer::ESCPOS>.
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 # Dependencies
 use 5.010;
@@ -18,3 +25,28 @@ no Moo;
 __PACKAGE__->meta->make_immutable;
 
 1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Printer::ESCPOS::Profiles::SinocanPSeries - Sinocan P Series Profile for Printers for L<Printer::ESCPOS>.
+
+=head1 VERSION
+
+version 1.006
+
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Printer/ESCPOS/Roles/Connection.pm
+++ b/lib/Printer/ESCPOS/Roles/Connection.pm
@@ -47,27 +47,6 @@ sub print {
     }
 }
 
-#sub print {
-#    my ( $self, $raw ) = @_;
-#    my @chunks;
-#
-#    my $printString;
-#    if ( defined $raw ) {
-#        $printString = $raw;
-#    }
-#    else {
-#        $printString = $self->_buffer;
-#        $self->_buffer('');
-#    }
-#    my $n = 64;    # Size of each chunk in bytes
-#
-#    @chunks = unpack "a$n" x ( ( length($printString) / $n ) - 1 ) . "a*",
-#      $printString;
-#    for my $chunk (@chunks) {
-#        $self->_connection->write($chunk);
-#    }
-#}
-
 1;
 
 __END__

--- a/lib/Printer/ESCPOS/Roles/Connection.pm
+++ b/lib/Printer/ESCPOS/Roles/Connection.pm
@@ -5,34 +5,91 @@ package Printer::ESCPOS::Roles::Connection;
 
 # PODNAME: Printer::ESCPOS::Roles::Connection
 # ABSTRACT: Role for Connection Classes for L<Printer::ESCPOS>
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 # Dependencies
 
 use 5.010;
 use Moo::Role;
 
-
 has _buffer => (
     is      => 'rw',
     default => '',
 );
 
-=method write
-
-Writes prepared data to the module buffer. This data is dispatched to printer with print() method. The print method
-takes care of buffer control issues.
-
-=cut
 
 sub write {
-    my ($self,$raw) = @_;
+    my ($self, $raw) = @_;
 
     $self->_buffer( $self->_buffer . $raw );
 }
 
-=method print
+sub print {
+    my ($self, $raw) = @_;
+
+    my $printString= defined $raw ? $raw : $self->_buffer;
+
+    return unless length $printString;
+
+    my $n = 64;
+    for (my $i = 0; $i < length($printString); $i += $n) {
+        my $chunk = substr($printString, $i, $n);
+
+        $self->write($chunk);
+    }
+}
+
+#sub print {
+#    my ( $self, $raw ) = @_;
+#    my @chunks;
+#
+#    my $printString;
+#    if ( defined $raw ) {
+#        $printString = $raw;
+#    }
+#    else {
+#        $printString = $self->_buffer;
+#        $self->_buffer('');
+#    }
+#    my $n = 64;    # Size of each chunk in bytes
+#
+#    @chunks = unpack "a$n" x ( ( length($printString) / $n ) - 1 ) . "a*",
+#      $printString;
+#    for my $chunk (@chunks) {
+#        $self->_connection->write($chunk);
+#    }
+#}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Printer::ESCPOS::Roles::Connection - Role for Connection Classes for L<Printer::ESCPOS>
+
+=head1 VERSION
+
+version 1.006
+
+=head1 METHODS
+
+=head2 write
+
+Writes prepared data to the module buffer. This data is dispatched to printer with print() method. The print method
+takes care of buffer control issues.
+
+=head2 print
 
 If a string is passed then it passes the string to the printer else passes the buffer data to the printer and clears
 the buffer.
@@ -40,25 +97,15 @@ the buffer.
     $device->printer->print(); # Prints and clears the Buffer.
     $device->printer->print($raw); # Prints $raw
 
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
 =cut
-
-sub print {
-    my ($self,$raw) = @_;
-    my @chunks;
-
-    my $printString;
-    if( defined $raw ) {
-        $printString = $raw;
-    } else {
-        $printString = $self->_buffer;
-        $self->_buffer('');
-    }
-    my $n = 64; # Size of each chunk in bytes
-
-    @chunks = unpack "a$n" x ((length($printString)/$n)-1) . "a*", $printString;
-    for my $chunk( @chunks ){
-        $self->_connection->write($chunk);
-    }
-}
-
-1;

--- a/lib/Printer/ESCPOS/Roles/Profile.pm
+++ b/lib/Printer/ESCPOS/Roles/Profile.pm
@@ -5,131 +5,159 @@ package Printer::ESCPOS::Roles::Profile;
 
 # PODNAME: Printer::ESCPOS::Roles::Profile
 # ABSTRACT: Role for all Printer Profiles for L<Printer::ESCPOS>
-# COPYRIGHT
-# VERSION
+#
+# This file is part of Printer-ESCPOS
+#
+# This software is copyright (c) 2017 by Shantanu Bhadoria.
+#
+# This is free software; you can redistribute it and/or modify it under
+# the same terms as the Perl 5 programming language system itself.
+#
+our $VERSION = '1.006'; # VERSION
 
 # Dependencies
 use 5.010;
 use Moo::Role;
 requires 'init';
 
-=attr driver
+
+has driver => (
+    is       => 'rw',
+    required => 1,
+);
+
+
+has usePrintMode => (
+    is      => 'rw',
+    default => '0',
+);
+
+
+has fontStyle => (
+    is      => 'rw',
+    default => 'a',
+);
+
+
+has emphasizedStatus => (
+    is      => 'rw',
+    default => 0,
+);
+
+
+has heightStatus => (
+    is      => 'rw',
+    default => 0,
+);
+
+
+has widthStatus => (
+    is      => 'rw',
+    default => 0,
+);
+
+
+has underlineStatus => (
+    is      => 'rw',
+    default => 0,
+);
+
+
+sub text {
+    my ( $self, $text ) = @_;
+    $self->driver->write($text);
+}
+
+
+sub print {
+    my ( $self, $text ) = @_;
+    $self->driver->print($text);
+}
+
+
+sub read {
+    my ( $self, $bytes ) = @_;
+    if ( $self->driver->can('read') ) {
+        return $self->driver->read($bytes);
+    }
+    else {
+        die
+"read is not supported by the Printer Driver in use use a different driverType $!";
+    }
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Printer::ESCPOS::Roles::Profile - Role for all Printer Profiles for L<Printer::ESCPOS>
+
+=head1 VERSION
+
+version 1.006
+
+=head1 ATTRIBUTES
+
+=head2 driver
 
 Stores the connection object from the Printer::ESCPOS::Connections::*. In any normal use case you must not modify this
 attribute.
 
-=cut
-
-has driver => (
-    is      => 'rw',
-    required => 1,
-);
-
-=attr usePrintMode
+=head2 usePrintMode
 
 Use Print mode to set font, underline, double width, double height and emphasized if false uses the individual command
 ESC M n for font "c" ESC M is forced irrespective of this flag
 
-=cut
-
-has usePrintMode => (
-  is      => 'rw',
-  default => '0',
-);
-
-=attr fontStyle
+=head2 fontStyle
 
 Set ESC-POS Font pass "a" "b" or "c". Note "c" is not supported across all printers.
 
-=cut
-
-has fontStyle => (
-  is      => 'rw',
-  default => 'a',
-);
-
-=attr emphasizedStatus
+=head2 emphasizedStatus
 
 Set/unset emphasized property
 
-=cut
-
-has emphasizedStatus => (
-  is      => 'rw',
-  default => 0,
-);
-
-=attr heightStatus
+=head2 heightStatus
 
 set unset double height property
 
-=cut
-
-has heightStatus => (
-  is      => 'rw',
-  default => 0,
-);
-
-=attr widthStatus
+=head2 widthStatus
 
 set unset double width property
 
-=cut
-
-has widthStatus => (
-  is      => 'rw',
-  default => 0,
-);
-
-=attr underlineStatus
+=head2 underlineStatus
 
 Set/unset underline property
 
-=cut
+=head1 METHODS
 
-has underlineStatus => (
-  is      => 'rw',
-  default => 0,
-);
-
-=method text
+=head2 text
 
 Sends raw text to the local buffer ready for sending this to the printer. This would contain a set of strings to print
 or ESCPOS Codes.
 
     $device->printer->text("Hello World\n");
 
-=cut
-
-sub text {
-    my ( $self, $text ) = @_;
-    $self->driver->write( $text );
-}
-
-=method print
+=head2 print
 
 prints data in the buffer
 
-=cut
-
-sub print {
-    my ( $self, $text ) = @_;
-    $self->driver->print( $text );
-}
-
-=method read
+=head2 read
 
 Reads n bytes from the printer. This function is used internally to get printer statuses when supported.
 
+=head1 AUTHOR
+
+Shantanu Bhadoria <shantanu@cpan.org> L<https://www.shantanubhadoria.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2017 by Shantanu Bhadoria.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
 =cut
-
-sub read {
-    my ( $self, $bytes ) = @_;
-    if( $self->driver->can( 'read' ) ) {
-        return $self->driver->read( $bytes );
-    } else {
-        die "read is not supported by the Printer Driver in use use a different driverType $!";
-    }
-}
-
-1;


### PR DESCRIPTION
…and standardize drivers

Fix basically everything.
I just wanted to do a quick fix on this code. I used AI for help on this one because I am not super familiar with Moo or this library. Therefore I am not promising perfect stability, but at least the library is functional.

Replaced broken unpack logic in Roles/Connection.pm with a substr loop. This prevents the "Repeat count cannot be negative" crash when sending basically anything to the printer.

Refactored USB.pm, Serial.pm, and File.pm to use a consistent write() method. This separates hardware-specific transmission from the Role's data-chunking logic.

Updated printAreaWidth in Generic.pm to have a default value.

Updated documentation to use "$device->printer->justify" instead of "$device->printer->justification".

I'm able to use a Rongta usb thermal printer with it over /dev/usb/lp0. At least on my end I have confirmed being able to print QR codes and images along with text after these fixes.